### PR TITLE
More accurately compensate missing ult charge

### DIFF
--- a/base_settings.opy
+++ b/base_settings.opy
@@ -117,16 +117,19 @@ settings {
             "reinhardt": {
                 "secondaryFireRechargeRate%": 139,
                 "ability1Cooldown%": 143,
-                "health%": percent(ow1_barrier_health_REINHARDT/ow2_barrier_health_REINHARDT)
+                "health%": percent(ow1_barrier_health_REINHARDT/ow2_barrier_health_REINHARDT),
+                "ultGen%": percent(ow1_ult_cost_REINHARDT/ow2_ult_cost_REINHARDT)
             },
             "roadhog": {
                 "ammoClipSize%": 83,
                 "ability1Cooldown%": 133,
-                "damageDealt%": 110
+                "damageDealt%": 110,
+                "ultGen%": percent(ow1_ult_cost_ROADHOG/ow2_ult_cost_ROADHOG)
             },
             "sigma": {
                 "secondaryFireRechargeRate%": 80,
                 "health%": percent(ow1_barrier_health_SIGMA/ow2_barrier_health_SIGMA),
+                "ultGen%": percent(ow1_ult_cost_SIGMA/ow2_ult_cost_SIGMA)
             },
             "soldier": {
                 "ultGen%": percent(ow1_ult_cost_SOLDIER/ow2_ult_cost_SOLDIER)
@@ -135,7 +138,8 @@ settings {
                 "ultGen%": percent(ow1_ult_cost_SOMBRA/ow2_ult_cost_SOMBRA)
             },
             "symmetra": {
-                "ammoClipSize%": 70
+                "ammoClipSize%": 70,
+                "ultGen%": percent(ow1_ult_cost_SYMMETRA/ow2_ult_cost_SYMMETRA)
             },
             "torbjorn": {
                 "ultGen%": percent(ow1_ult_cost_TORBJORN/ow2_ult_cost_TORBJORN)

--- a/base_settings.opy
+++ b/base_settings.opy
@@ -58,98 +58,98 @@ settings {
                 "ammoClipSize%": 80,
                 "damageDealt%": 93,
                 "ability1Cooldown%": 86,
-                "ultGen%": percent(ow1_ult_cost_ANA/ow2_ult_cost_ANA)
+                "ultGen%": percent(ow2_ult_cost_ANA/ow1_ult_cost_ANA)
             },
             "ashe": {
-                "ultGen%": percent(ow1_ult_cost_ASHE/ow2_ult_cost_ASHE)
+                "ultGen%": percent(ow2_ult_cost_ASHE/ow1_ult_cost_ASHE)
             },
             "baptiste": {
                 "ammoClipSize%": 87,
                 "ability2Cooldown%": 109,
-                "ultGen%": percent(ow1_ult_cost_BAPTISTE/ow2_ult_cost_BAPTISTE)
+                "ultGen%": percent(ow2_ult_cost_BAPTISTE/ow1_ult_cost_BAPTISTE)
             },
             "bastion": {
-                "ultGen%": percent(ow1_ult_cost_BASTION/ow2_ult_cost_BASTION)
+                "ultGen%": percent(ow2_ult_cost_BASTION/ow1_ult_cost_BASTION)
             },
             "brigitte": {
-                "ultGen%": percent(ow1_ult_cost_BRIGITTE/ow2_ult_cost_BRIGITTE)
+                "ultGen%": percent(ow2_ult_cost_BRIGITTE/ow1_ult_cost_BRIGITTE)
             },
             "mccree": {
-                "ultGen%": percent(ow1_ult_cost_MCCREE/ow2_ult_cost_MCCREE)
+                "ultGen%": percent(ow2_ult_cost_MCCREE/ow1_ult_cost_MCCREE)
             },
             "dva": {
                 "secondaryFireMaximumTime%": 67,
                 "ability2Cooldown%": 114,
-                "ultGen%": percent(ow1_ult_cost_DVA/ow2_ult_cost_DVA)
+                "ultGen%": percent(ow2_ult_cost_DVA/ow1_ult_cost_DVA)
             },
             "echo": {
-                "ultGen%": percent(ow1_ult_cost_ECHO/ow2_ult_cost_ECHO)
+                "ultGen%": percent(ow2_ult_cost_ECHO/ow1_ult_cost_ECHO)
             },
             "genji": {
                 "ammoClipSize%": percent(ow1_ammo_count_GENJI/ow2_ammo_count_GENJI),
                 "damageDealt%": 107,
-                "ultGen%": percent(ow1_ult_cost_GENJI/ow2_ult_cost_GENJI)
+                "ultGen%": percent(ow2_ult_cost_GENJI/ow1_ult_cost_GENJI)
             },
             "hanzo": {
-                "ultGen%": percent(ow1_ult_cost_HANZO/ow2_ult_cost_HANZO)
+                "ultGen%": percent(ow2_ult_cost_HANZO/ow1_ult_cost_HANZO)
             },
             "junkrat": {
-                "ultGen%": percent(ow1_ult_cost_JUNKRAT/ow2_ult_cost_JUNKRAT)
+                "ultGen%": percent(ow2_ult_cost_JUNKRAT/ow1_ult_cost_JUNKRAT)
             },
             "lucio": {
-                "ultGen%": percent(ow1_ult_cost_LUCIO/ow2_ult_cost_LUCIO)
+                "ultGen%": percent(ow2_ult_cost_LUCIO/ow1_ult_cost_LUCIO)
             },
             "mei": {
-                "ultGen%": percent(ow1_ult_cost_MEI/ow2_ult_cost_MEI)
+                "ultGen%": percent(ow2_ult_cost_MEI/ow1_ult_cost_MEI)
             },
             "mercy": {
-                "ultGen%": percent(ow1_ult_cost_MERCY/ow2_ult_cost_MERCY)
+                "ultGen%": percent(ow2_ult_cost_MERCY/ow1_ult_cost_MERCY)
             },
             "moira": {
-                "ultGen%": percent(ow1_ult_cost_MOIRA/ow2_ult_cost_MOIRA)
+                "ultGen%": percent(ow2_ult_cost_MOIRA/ow1_ult_cost_MOIRA)
             },
             "pharah": {
-                "ultGen%": percent(ow1_ult_cost_PHARAH/ow2_ult_cost_PHARAH)
+                "ultGen%": percent(ow2_ult_cost_PHARAH/ow1_ult_cost_PHARAH)
             },
             "reaper": {
-                "ultGen%": percent(ow1_ult_cost_REAPER/ow2_ult_cost_REAPER)
+                "ultGen%": percent(ow2_ult_cost_REAPER/ow1_ult_cost_REAPER)
             },
             "reinhardt": {
                 "secondaryFireRechargeRate%": 139,
                 "ability1Cooldown%": 143,
                 "health%": percent(ow1_barrier_health_REINHARDT/ow2_barrier_health_REINHARDT),
-                "ultGen%": percent(ow1_ult_cost_REINHARDT/ow2_ult_cost_REINHARDT)
+                "ultGen%": percent(ow2_ult_cost_REINHARDT/ow1_ult_cost_REINHARDT)
             },
             "roadhog": {
                 "ammoClipSize%": 83,
                 "ability1Cooldown%": 133,
                 "damageDealt%": 110,
-                "ultGen%": percent(ow1_ult_cost_ROADHOG/ow2_ult_cost_ROADHOG)
+                "ultGen%": percent(ow2_ult_cost_ROADHOG/ow1_ult_cost_ROADHOG)
             },
             "sigma": {
                 "secondaryFireRechargeRate%": 80,
                 "health%": percent(ow1_barrier_health_SIGMA/ow2_barrier_health_SIGMA),
-                "ultGen%": percent(ow1_ult_cost_SIGMA/ow2_ult_cost_SIGMA)
+                "ultGen%": percent(ow2_ult_cost_SIGMA/ow1_ult_cost_SIGMA)
             },
             "soldier": {
-                "ultGen%": percent(ow1_ult_cost_SOLDIER/ow2_ult_cost_SOLDIER)
+                "ultGen%": percent(ow2_ult_cost_SOLDIER/ow1_ult_cost_SOLDIER)
             },
             "sombra": {
-                "ultGen%": percent(ow1_ult_cost_SOMBRA/ow2_ult_cost_SOMBRA)
+                "ultGen%": percent(ow2_ult_cost_SOMBRA/ow1_ult_cost_SOMBRA)
             },
             "symmetra": {
                 "ammoClipSize%": 70,
-                "ultGen%": percent(ow1_ult_cost_SYMMETRA/ow2_ult_cost_SYMMETRA)
+                "ultGen%": percent(ow2_ult_cost_SYMMETRA/ow1_ult_cost_SYMMETRA)
             },
             "torbjorn": {
-                "ultGen%": percent(ow1_ult_cost_TORBJORN/ow2_ult_cost_TORBJORN)
+                "ultGen%": percent(ow2_ult_cost_TORBJORN/ow1_ult_cost_TORBJORN)
             },
             "tracer": {
                 "damageDealt%": 109,
-                "ultGen%": percent(ow1_ult_cost_TRACER/ow2_ult_cost_TRACER)
+                "ultGen%": percent(ow2_ult_cost_TRACER/ow1_ult_cost_TRACER)
             },
             "widowmaker": {
-                "ultGen%": percent(ow1_ult_cost_WIDOWMAKER/ow2_ult_cost_WIDOWMAKER)
+                "ultGen%": percent(ow2_ult_cost_WIDOWMAKER/ow1_ult_cost_WIDOWMAKER)
             },
             "winston": {
                 "ability2Cooldown%": 108,
@@ -158,14 +158,14 @@ settings {
                 "health%": percent(ow1_barrier_health_WINSTON/ow2_barrier_health_WINSTON),
             },
             "hammond": {
-                "ultGen%": percent(ow1_ult_cost_HAMMOND/ow2_ult_cost_HAMMOND)
+                "ultGen%": percent(ow2_ult_cost_HAMMOND/ow1_ult_cost_HAMMOND)
             },
             "zarya": {
                 "ability2Cooldown%": 80,
                 "health%": percent(ow1_barrier_health_ZARYA/ow2_barrier_health_ZARYA),
             },
             "zenyatta": {
-                "ultGen%": percent(ow1_ult_cost_ZENYATTA/ow2_ult_cost_ZENYATTA)
+                "ultGen%": percent(ow2_ult_cost_ZENYATTA/ow1_ult_cost_ZENYATTA)
             },
             "disabledHeroes": [
                 "doomfist",

--- a/ult_charge.opy
+++ b/ult_charge.opy
@@ -42,6 +42,15 @@ rule "initialize overwatch 1 ultimate costs":
     ult_cost[heroID(Hero.MOIRA)] = 1/(roundedPercent(ow2_ult_cost_MOIRA/ow1_ult_cost_MOIRA)/100)*ow2_ult_cost_MOIRA
     ult_cost[heroID(Hero.ZENYATTA)] = 1/(roundedPercent(ow2_ult_cost_ZENYATTA/ow1_ult_cost_ZENYATTA)/100)*ow2_ult_cost_ZENYATTA
 
+def compensateUltPercent():
+    @Name "[ult_charge.opy]: Compensate missing ultimate percentage"
+    
+    while percent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id]) >= 1:
+        eventPlayer.ult_percent_compensated = roundedPercent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id])
+        eventPlayer.setUltCharge(eventPlayer.getUltCharge() + eventPlayer.ult_percent_compensated)
+        eventPlayer.ult_charge_compensated = percentOf(eventPlayer.ult_percent_compensated, ult_cost[eventPlayer.hero_id])
+        eventPlayer.missing_ult_points -= eventPlayer.ult_charge_compensated
+
 rule "Remember missing ult charge from damaging tank":
     @Event playerDealtDamage
     @Condition victim != eventPlayer
@@ -49,6 +58,7 @@ rule "Remember missing ult charge from damaging tank":
     @Condition not eventPlayer.isUsingUltimate()
 
     eventPlayer.missing_ult_points += 0.3*eventDamage
+    compensateUltPercent()
 
 rule "Remember missing ult charge from healing tank":
     @Event playerDealtHealing
@@ -56,17 +66,7 @@ rule "Remember missing ult charge from healing tank":
     @Condition not eventPlayer.isUsingUltimate()
 
     eventPlayer.missing_ult_points += 0.3*eventHealing
-
-rule "Compensate missing ult charge":
-    @Event eachPlayer
-    @Condition percent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id]) >= 1
-
-    do:
-        eventPlayer.ult_percent_compensated = roundedPercent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id])
-        eventPlayer.setUltCharge(eventPlayer.getUltCharge() + eventPlayer.ult_percent_compensated)
-        eventPlayer.ult_charge_compensated = percentOf(eventPlayer.ult_percent_compensated, ult_cost[eventPlayer.hero_id])
-        eventPlayer.missing_ult_points -= eventPlayer.ult_charge_compensated
-    while (RULE_CONDITION)
+    compensateUltPercent()
 
 rule "Reset ult compensation after using ult or switching hero":
     @Event eachPlayer

--- a/ult_charge.opy
+++ b/ult_charge.opy
@@ -45,8 +45,8 @@ rule "initialize overwatch 1 ultimate costs":
 def compensateUltPercent():
     @Name "[ult_charge.opy]: Compensate missing ultimate percentage"
     
-    while percent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id]) >= 1:
-        eventPlayer.ult_percent_compensated = roundedPercent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id])
+    if eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id] > 0:
+        eventPlayer.ult_percent_compensated = percent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id]) + 3 # add 3% extra to compensate for rounding error
         eventPlayer.setUltCharge(eventPlayer.getUltCharge() + eventPlayer.ult_percent_compensated)
         eventPlayer.ult_charge_compensated = percentOf(eventPlayer.ult_percent_compensated, ult_cost[eventPlayer.hero_id])
         eventPlayer.missing_ult_points -= eventPlayer.ult_charge_compensated

--- a/ult_charge.opy
+++ b/ult_charge.opy
@@ -11,36 +11,36 @@ playervar ult_percent_compensated
 playervar ult_charge_compensated
 
 rule "initialize overwatch 1 ultimate costs":
-    ult_cost[heroID(Hero.DVA)] = percentOf(roundedPercent(ow1_ult_cost_DVA/ow2_ult_cost_DVA), ow2_ult_cost_DVA)
-    ult_cost[heroID(Hero.REINHARDT)] = percentOf(roundedPercent(ow1_ult_cost_REINHARDT/ow2_ult_cost_REINHARDT), ow2_ult_cost_REINHARDT)
-    ult_cost[heroID(Hero.ROADHOG)] = percentOf(roundedPercent(ow1_ult_cost_ROADHOG/ow2_ult_cost_ROADHOG), ow2_ult_cost_ROADHOG)
-    ult_cost[heroID(Hero.SIGMA)] = percentOf(roundedPercent(ow1_ult_cost_SIGMA/ow2_ult_cost_SIGMA), ow2_ult_cost_SIGMA)
-    ult_cost[heroID(Hero.WINSTON)] = percentOf(roundedPercent(ow1_ult_cost_WINSTON/ow2_ult_cost_WINSTON), ow2_ult_cost_WINSTON)
-    ult_cost[heroID(Hero.HAMMOND)] = percentOf(roundedPercent(ow1_ult_cost_HAMMOND/ow2_ult_cost_HAMMOND), ow2_ult_cost_HAMMOND)
-    ult_cost[heroID(Hero.ZARYA)] = percentOf(roundedPercent(ow1_ult_cost_ZARYA/ow2_ult_cost_ZARYA), ow2_ult_cost_ZARYA)
-    ult_cost[heroID(Hero.ASHE)] = percentOf(roundedPercent(ow1_ult_cost_ASHE/ow2_ult_cost_ASHE), ow2_ult_cost_ASHE)
-    ult_cost[heroID(Hero.BASTION)] = percentOf(roundedPercent(ow1_ult_cost_BASTION/ow2_ult_cost_BASTION), ow2_ult_cost_BASTION)
-    ult_cost[heroID(Hero.MCCREE)] = percentOf(roundedPercent(ow1_ult_cost_MCCREE/ow2_ult_cost_MCCREE), ow2_ult_cost_MCCREE)
-    ult_cost[heroID(Hero.ECHO)] = percentOf(roundedPercent(ow1_ult_cost_ECHO/ow2_ult_cost_ECHO), ow2_ult_cost_ECHO)
-    ult_cost[heroID(Hero.GENJI)] = percentOf(roundedPercent(ow1_ult_cost_GENJI/ow2_ult_cost_GENJI), ow2_ult_cost_GENJI)
-    ult_cost[heroID(Hero.HANZO)] = percentOf(roundedPercent(ow1_ult_cost_HANZO/ow2_ult_cost_HANZO), ow2_ult_cost_HANZO)
-    ult_cost[heroID(Hero.JUNKRAT)] = percentOf(roundedPercent(ow1_ult_cost_JUNKRAT/ow2_ult_cost_JUNKRAT), ow2_ult_cost_JUNKRAT)
-    ult_cost[heroID(Hero.MEI)] = percentOf(roundedPercent(ow1_ult_cost_MEI/ow2_ult_cost_MEI), ow2_ult_cost_MEI)
-    ult_cost[heroID(Hero.PHARAH)] = percentOf(roundedPercent(ow1_ult_cost_PHARAH/ow2_ult_cost_PHARAH), ow2_ult_cost_PHARAH)
-    ult_cost[heroID(Hero.REAPER)] = percentOf(roundedPercent(ow1_ult_cost_REAPER/ow2_ult_cost_REAPER), ow2_ult_cost_REAPER)
-    ult_cost[heroID(Hero.SOLDIER)] = percentOf(roundedPercent(ow1_ult_cost_SOLDIER/ow2_ult_cost_SOLDIER), ow2_ult_cost_SOLDIER)
-    ult_cost[heroID(Hero.SOMBRA)] = percentOf(roundedPercent(ow1_ult_cost_SOMBRA/ow2_ult_cost_SOMBRA), ow2_ult_cost_SOMBRA)
-    ult_cost[heroID(Hero.SYMMETRA)] = percentOf(roundedPercent(ow1_ult_cost_SYMMETRA/ow2_ult_cost_SYMMETRA), ow2_ult_cost_SYMMETRA)
-    ult_cost[heroID(Hero.TORBJORN)] = percentOf(roundedPercent(ow1_ult_cost_TORBJORN/ow2_ult_cost_TORBJORN), ow2_ult_cost_TORBJORN)
-    ult_cost[heroID(Hero.TRACER)] = percentOf(roundedPercent(ow1_ult_cost_TRACER/ow2_ult_cost_TRACER), ow2_ult_cost_TRACER)
-    ult_cost[heroID(Hero.WIDOWMAKER)] = percentOf(roundedPercent(ow1_ult_cost_WIDOWMAKER/ow2_ult_cost_WIDOWMAKER), ow2_ult_cost_WIDOWMAKER)
-    ult_cost[heroID(Hero.ANA)] = percentOf(roundedPercent(ow1_ult_cost_ANA/ow2_ult_cost_ANA), ow2_ult_cost_ANA)
-    ult_cost[heroID(Hero.BAPTISTE)] = percentOf(roundedPercent(ow1_ult_cost_BAPTISTE/ow2_ult_cost_BAPTISTE), ow2_ult_cost_BAPTISTE)
-    ult_cost[heroID(Hero.BRIGITTE)] = percentOf(roundedPercent(ow1_ult_cost_BRIGITTE/ow2_ult_cost_BRIGITTE), ow2_ult_cost_BRIGITTE)
-    ult_cost[heroID(Hero.LUCIO)] = percentOf(roundedPercent(ow1_ult_cost_LUCIO/ow2_ult_cost_LUCIO), ow2_ult_cost_LUCIO)
-    ult_cost[heroID(Hero.MERCY)] = percentOf(roundedPercent(ow1_ult_cost_MERCY/ow2_ult_cost_MERCY), ow2_ult_cost_MERCY)
-    ult_cost[heroID(Hero.MOIRA)] = percentOf(roundedPercent(ow1_ult_cost_MOIRA/ow2_ult_cost_MOIRA), ow2_ult_cost_MOIRA)
-    ult_cost[heroID(Hero.ZENYATTA)] = percentOf(roundedPercent(ow1_ult_cost_ZENYATTA/ow2_ult_cost_ZENYATTA), ow2_ult_cost_ZENYATTA)
+    ult_cost[heroID(Hero.DVA)] = 1/(roundedPercent(ow2_ult_cost_DVA/ow1_ult_cost_DVA)/100)*ow2_ult_cost_DVA
+    ult_cost[heroID(Hero.REINHARDT)] = 1/(roundedPercent(ow2_ult_cost_REINHARDT/ow1_ult_cost_REINHARDT)/100)*ow2_ult_cost_REINHARDT
+    ult_cost[heroID(Hero.ROADHOG)] = 1/(roundedPercent(ow2_ult_cost_ROADHOG/ow1_ult_cost_ROADHOG)/100)*ow2_ult_cost_ROADHOG
+    ult_cost[heroID(Hero.SIGMA)] = 1/(roundedPercent(ow2_ult_cost_SIGMA/ow1_ult_cost_SIGMA)/100)*ow2_ult_cost_SIGMA
+    ult_cost[heroID(Hero.WINSTON)] = 1/(roundedPercent(ow2_ult_cost_WINSTON/ow1_ult_cost_WINSTON)/100)*ow2_ult_cost_WINSTON
+    ult_cost[heroID(Hero.HAMMOND)] = 1/(roundedPercent(ow2_ult_cost_HAMMOND/ow1_ult_cost_HAMMOND)/100)*ow2_ult_cost_HAMMOND
+    ult_cost[heroID(Hero.ZARYA)] = 1/(roundedPercent(ow2_ult_cost_ZARYA/ow1_ult_cost_ZARYA)/100)*ow2_ult_cost_ZARYA
+    ult_cost[heroID(Hero.ASHE)] = 1/(roundedPercent(ow2_ult_cost_ASHE/ow1_ult_cost_ASHE)/100)*ow2_ult_cost_ASHE
+    ult_cost[heroID(Hero.BASTION)] = 1/(roundedPercent(ow2_ult_cost_BASTION/ow1_ult_cost_BASTION)/100)*ow2_ult_cost_BASTION
+    ult_cost[heroID(Hero.MCCREE)] = 1/(roundedPercent(ow2_ult_cost_MCCREE/ow1_ult_cost_MCCREE)/100)*ow2_ult_cost_MCCREE
+    ult_cost[heroID(Hero.ECHO)] = 1/(roundedPercent(ow2_ult_cost_ECHO/ow1_ult_cost_ECHO)/100)*ow2_ult_cost_ECHO
+    ult_cost[heroID(Hero.GENJI)] = 1/(roundedPercent(ow2_ult_cost_GENJI/ow1_ult_cost_GENJI)/100)*ow2_ult_cost_GENJI
+    ult_cost[heroID(Hero.HANZO)] = 1/(roundedPercent(ow2_ult_cost_HANZO/ow1_ult_cost_HANZO)/100)*ow2_ult_cost_HANZO
+    ult_cost[heroID(Hero.JUNKRAT)] = 1/(roundedPercent(ow2_ult_cost_JUNKRAT/ow1_ult_cost_JUNKRAT)/100)*ow2_ult_cost_JUNKRAT
+    ult_cost[heroID(Hero.MEI)] = 1/(roundedPercent(ow2_ult_cost_MEI/ow1_ult_cost_MEI)/100)*ow2_ult_cost_MEI
+    ult_cost[heroID(Hero.PHARAH)] = 1/(roundedPercent(ow2_ult_cost_PHARAH/ow1_ult_cost_PHARAH)/100)*ow2_ult_cost_PHARAH
+    ult_cost[heroID(Hero.REAPER)] = 1/(roundedPercent(ow2_ult_cost_REAPER/ow1_ult_cost_REAPER)/100)*ow2_ult_cost_REAPER
+    ult_cost[heroID(Hero.SOLDIER)] = 1/(roundedPercent(ow2_ult_cost_SOLDIER/ow1_ult_cost_SOLDIER)/100)*ow2_ult_cost_SOLDIER
+    ult_cost[heroID(Hero.SOMBRA)] = 1/(roundedPercent(ow2_ult_cost_SOMBRA/ow1_ult_cost_SOMBRA)/100)*ow2_ult_cost_SOMBRA
+    ult_cost[heroID(Hero.SYMMETRA)] = 1/(roundedPercent(ow2_ult_cost_SYMMETRA/ow1_ult_cost_SYMMETRA)/100)*ow2_ult_cost_SYMMETRA
+    ult_cost[heroID(Hero.TORBJORN)] = 1/(roundedPercent(ow2_ult_cost_TORBJORN/ow1_ult_cost_TORBJORN)/100)*ow2_ult_cost_TORBJORN
+    ult_cost[heroID(Hero.TRACER)] = 1/(roundedPercent(ow2_ult_cost_TRACER/ow1_ult_cost_TRACER)/100)*ow2_ult_cost_TRACER
+    ult_cost[heroID(Hero.WIDOWMAKER)] = 1/(roundedPercent(ow2_ult_cost_WIDOWMAKER/ow1_ult_cost_WIDOWMAKER)/100)*ow2_ult_cost_WIDOWMAKER
+    ult_cost[heroID(Hero.ANA)] = 1/(roundedPercent(ow2_ult_cost_ANA/ow1_ult_cost_ANA)/100)*ow2_ult_cost_ANA
+    ult_cost[heroID(Hero.BAPTISTE)] = 1/(roundedPercent(ow2_ult_cost_BAPTISTE/ow1_ult_cost_BAPTISTE)/100)*ow2_ult_cost_BAPTISTE
+    ult_cost[heroID(Hero.BRIGITTE)] = 1/(roundedPercent(ow2_ult_cost_BRIGITTE/ow1_ult_cost_BRIGITTE)/100)*ow2_ult_cost_BRIGITTE
+    ult_cost[heroID(Hero.LUCIO)] = 1/(roundedPercent(ow2_ult_cost_LUCIO/ow1_ult_cost_LUCIO)/100)*ow2_ult_cost_LUCIO
+    ult_cost[heroID(Hero.MERCY)] = 1/(roundedPercent(ow2_ult_cost_MERCY/ow1_ult_cost_MERCY)/100)*ow2_ult_cost_MERCY
+    ult_cost[heroID(Hero.MOIRA)] = 1/(roundedPercent(ow2_ult_cost_MOIRA/ow1_ult_cost_MOIRA)/100)*ow2_ult_cost_MOIRA
+    ult_cost[heroID(Hero.ZENYATTA)] = 1/(roundedPercent(ow2_ult_cost_ZENYATTA/ow1_ult_cost_ZENYATTA)/100)*ow2_ult_cost_ZENYATTA
 
 rule "Remember missing ult charge from damaging tank":
     @Event playerDealtDamage

--- a/ult_charge.opy
+++ b/ult_charge.opy
@@ -1,44 +1,46 @@
 #!include "./utilities.opy"
 #!include "./ow1_constants.opy"
+#!include "./ow2_constants.opy"
 
 # Global variables
 globalvar ult_cost
 
 # Player variables
 playervar missing_ult_points
-playervar ult_compensation
+playervar ult_percent_compensated
+playervar ult_charge_compensated
 
 rule "initialize overwatch 1 ultimate costs":
-    ult_cost[heroID(Hero.DVA)] = ow1_ult_cost_DVA
-    ult_cost[heroID(Hero.REINHARDT)] = ow1_ult_cost_REINHARDT
-    ult_cost[heroID(Hero.ROADHOG)] = ow1_ult_cost_ROADHOG
-    ult_cost[heroID(Hero.SIGMA)] = ow1_ult_cost_SIGMA
-    ult_cost[heroID(Hero.WINSTON)] = ow1_ult_cost_WINSTON
-    ult_cost[heroID(Hero.HAMMOND)] = ow1_ult_cost_HAMMOND
-    ult_cost[heroID(Hero.ZARYA)] = ow1_ult_cost_ZARYA
-    ult_cost[heroID(Hero.ASHE)] = ow1_ult_cost_ASHE
-    ult_cost[heroID(Hero.BASTION)] = ow1_ult_cost_BASTION
-    ult_cost[heroID(Hero.MCCREE)] = ow1_ult_cost_MCCREE
-    ult_cost[heroID(Hero.ECHO)] = ow1_ult_cost_ECHO
-    ult_cost[heroID(Hero.GENJI)] = ow1_ult_cost_GENJI
-    ult_cost[heroID(Hero.HANZO)] = ow1_ult_cost_HANZO
-    ult_cost[heroID(Hero.JUNKRAT)] = ow1_ult_cost_JUNKRAT
-    ult_cost[heroID(Hero.MEI)] = ow1_ult_cost_MEI
-    ult_cost[heroID(Hero.PHARAH)] = ow1_ult_cost_PHARAH
-    ult_cost[heroID(Hero.REAPER)] = ow1_ult_cost_REAPER
-    ult_cost[heroID(Hero.SOLDIER)] = ow1_ult_cost_SOLDIER
-    ult_cost[heroID(Hero.SOMBRA)] = ow1_ult_cost_SOMBRA
-    ult_cost[heroID(Hero.SYMMETRA)] = ow1_ult_cost_SYMMETRA
-    ult_cost[heroID(Hero.TORBJORN)] = ow1_ult_cost_TORBJORN
-    ult_cost[heroID(Hero.TRACER)] = ow1_ult_cost_TRACER
-    ult_cost[heroID(Hero.WIDOWMAKER)] = ow1_ult_cost_WIDOWMAKER
-    ult_cost[heroID(Hero.ANA)] = ow1_ult_cost_ANA
-    ult_cost[heroID(Hero.BAPTISTE)] = ow1_ult_cost_BAPTISTE
-    ult_cost[heroID(Hero.BRIGITTE)] = ow1_ult_cost_BRIGITTE
-    ult_cost[heroID(Hero.LUCIO)] = ow1_ult_cost_LUCIO
-    ult_cost[heroID(Hero.MERCY)] = ow1_ult_cost_MERCY
-    ult_cost[heroID(Hero.MOIRA)] = ow1_ult_cost_MOIRA
-    ult_cost[heroID(Hero.ZENYATTA)] = ow1_ult_cost_ZENYATTA
+    ult_cost[heroID(Hero.DVA)] = percentOf(roundedPercent(ow1_ult_cost_DVA/ow2_ult_cost_DVA), ow2_ult_cost_DVA)
+    ult_cost[heroID(Hero.REINHARDT)] = percentOf(roundedPercent(ow1_ult_cost_REINHARDT/ow2_ult_cost_REINHARDT), ow2_ult_cost_REINHARDT)
+    ult_cost[heroID(Hero.ROADHOG)] = percentOf(roundedPercent(ow1_ult_cost_ROADHOG/ow2_ult_cost_ROADHOG), ow2_ult_cost_ROADHOG)
+    ult_cost[heroID(Hero.SIGMA)] = percentOf(roundedPercent(ow1_ult_cost_SIGMA/ow2_ult_cost_SIGMA), ow2_ult_cost_SIGMA)
+    ult_cost[heroID(Hero.WINSTON)] = percentOf(roundedPercent(ow1_ult_cost_WINSTON/ow2_ult_cost_WINSTON), ow2_ult_cost_WINSTON)
+    ult_cost[heroID(Hero.HAMMOND)] = percentOf(roundedPercent(ow1_ult_cost_HAMMOND/ow2_ult_cost_HAMMOND), ow2_ult_cost_HAMMOND)
+    ult_cost[heroID(Hero.ZARYA)] = percentOf(roundedPercent(ow1_ult_cost_ZARYA/ow2_ult_cost_ZARYA), ow2_ult_cost_ZARYA)
+    ult_cost[heroID(Hero.ASHE)] = percentOf(roundedPercent(ow1_ult_cost_ASHE/ow2_ult_cost_ASHE), ow2_ult_cost_ASHE)
+    ult_cost[heroID(Hero.BASTION)] = percentOf(roundedPercent(ow1_ult_cost_BASTION/ow2_ult_cost_BASTION), ow2_ult_cost_BASTION)
+    ult_cost[heroID(Hero.MCCREE)] = percentOf(roundedPercent(ow1_ult_cost_MCCREE/ow2_ult_cost_MCCREE), ow2_ult_cost_MCCREE)
+    ult_cost[heroID(Hero.ECHO)] = percentOf(roundedPercent(ow1_ult_cost_ECHO/ow2_ult_cost_ECHO), ow2_ult_cost_ECHO)
+    ult_cost[heroID(Hero.GENJI)] = percentOf(roundedPercent(ow1_ult_cost_GENJI/ow2_ult_cost_GENJI), ow2_ult_cost_GENJI)
+    ult_cost[heroID(Hero.HANZO)] = percentOf(roundedPercent(ow1_ult_cost_HANZO/ow2_ult_cost_HANZO), ow2_ult_cost_HANZO)
+    ult_cost[heroID(Hero.JUNKRAT)] = percentOf(roundedPercent(ow1_ult_cost_JUNKRAT/ow2_ult_cost_JUNKRAT), ow2_ult_cost_JUNKRAT)
+    ult_cost[heroID(Hero.MEI)] = percentOf(roundedPercent(ow1_ult_cost_MEI/ow2_ult_cost_MEI), ow2_ult_cost_MEI)
+    ult_cost[heroID(Hero.PHARAH)] = percentOf(roundedPercent(ow1_ult_cost_PHARAH/ow2_ult_cost_PHARAH), ow2_ult_cost_PHARAH)
+    ult_cost[heroID(Hero.REAPER)] = percentOf(roundedPercent(ow1_ult_cost_REAPER/ow2_ult_cost_REAPER), ow2_ult_cost_REAPER)
+    ult_cost[heroID(Hero.SOLDIER)] = percentOf(roundedPercent(ow1_ult_cost_SOLDIER/ow2_ult_cost_SOLDIER), ow2_ult_cost_SOLDIER)
+    ult_cost[heroID(Hero.SOMBRA)] = percentOf(roundedPercent(ow1_ult_cost_SOMBRA/ow2_ult_cost_SOMBRA), ow2_ult_cost_SOMBRA)
+    ult_cost[heroID(Hero.SYMMETRA)] = percentOf(roundedPercent(ow1_ult_cost_SYMMETRA/ow2_ult_cost_SYMMETRA), ow2_ult_cost_SYMMETRA)
+    ult_cost[heroID(Hero.TORBJORN)] = percentOf(roundedPercent(ow1_ult_cost_TORBJORN/ow2_ult_cost_TORBJORN), ow2_ult_cost_TORBJORN)
+    ult_cost[heroID(Hero.TRACER)] = percentOf(roundedPercent(ow1_ult_cost_TRACER/ow2_ult_cost_TRACER), ow2_ult_cost_TRACER)
+    ult_cost[heroID(Hero.WIDOWMAKER)] = percentOf(roundedPercent(ow1_ult_cost_WIDOWMAKER/ow2_ult_cost_WIDOWMAKER), ow2_ult_cost_WIDOWMAKER)
+    ult_cost[heroID(Hero.ANA)] = percentOf(roundedPercent(ow1_ult_cost_ANA/ow2_ult_cost_ANA), ow2_ult_cost_ANA)
+    ult_cost[heroID(Hero.BAPTISTE)] = percentOf(roundedPercent(ow1_ult_cost_BAPTISTE/ow2_ult_cost_BAPTISTE), ow2_ult_cost_BAPTISTE)
+    ult_cost[heroID(Hero.BRIGITTE)] = percentOf(roundedPercent(ow1_ult_cost_BRIGITTE/ow2_ult_cost_BRIGITTE), ow2_ult_cost_BRIGITTE)
+    ult_cost[heroID(Hero.LUCIO)] = percentOf(roundedPercent(ow1_ult_cost_LUCIO/ow2_ult_cost_LUCIO), ow2_ult_cost_LUCIO)
+    ult_cost[heroID(Hero.MERCY)] = percentOf(roundedPercent(ow1_ult_cost_MERCY/ow2_ult_cost_MERCY), ow2_ult_cost_MERCY)
+    ult_cost[heroID(Hero.MOIRA)] = percentOf(roundedPercent(ow1_ult_cost_MOIRA/ow2_ult_cost_MOIRA), ow2_ult_cost_MOIRA)
+    ult_cost[heroID(Hero.ZENYATTA)] = percentOf(roundedPercent(ow1_ult_cost_ZENYATTA/ow2_ult_cost_ZENYATTA), ow2_ult_cost_ZENYATTA)
 
 rule "Remember missing ult charge from damaging tank":
     @Event playerDealtDamage
@@ -57,12 +59,13 @@ rule "Remember missing ult charge from healing tank":
 
 rule "Compensate missing ult charge":
     @Event eachPlayer
-    @Condition eventPlayer.missing_ult_points/ult_cost[heroID(eventPlayer.getCurrentHero())] >= 0.01
+    @Condition percent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id]) >= 1
 
     do:
-        eventPlayer.ult_compensation = percent(eventPlayer.missing_ult_points/ult_cost[heroID(eventPlayer.getCurrentHero())])
-        eventPlayer.setUltCharge(eventPlayer.getUltCharge() + eventPlayer.ult_compensation)
-        eventPlayer.missing_ult_points = eventPlayer.missing_ult_points - round(eventPlayer.ult_compensation)/100*ult_cost[heroID(eventPlayer.getCurrentHero())]
+        eventPlayer.ult_percent_compensated = roundedPercent(eventPlayer.missing_ult_points/ult_cost[eventPlayer.hero_id])
+        eventPlayer.setUltCharge(eventPlayer.getUltCharge() + eventPlayer.ult_percent_compensated)
+        eventPlayer.ult_charge_compensated = percentOf(eventPlayer.ult_percent_compensated, ult_cost[eventPlayer.hero_id])
+        eventPlayer.missing_ult_points -= eventPlayer.ult_charge_compensated
     while (RULE_CONDITION)
 
 rule "Reset ult compensation after using ult or switching hero":
@@ -70,7 +73,7 @@ rule "Reset ult compensation after using ult or switching hero":
     @Condition eventPlayer.isUsingUltimate() or eventPlayer.hero_switched
 
     eventPlayer.missing_ult_points = 0
-    eventPlayer.ult_compensation = 0
+    eventPlayer.ult_percent_compensated = 0
 
 rule "Reset ult charge on hero switch":
     @Event eachPlayer

--- a/ult_charge.opy
+++ b/ult_charge.opy
@@ -44,12 +44,14 @@ rule "Remember missing ult charge from damaging tank":
     @Event playerDealtDamage
     @Condition victim != eventPlayer
     @Condition any([victim.getCurrentHero() == tank_hero for tank_hero in getTankHeroes()])
+    @Condition not eventPlayer.isUsingUltimate()
 
     eventPlayer.missing_ult_points += 0.3*eventDamage
 
 rule "Remember missing ult charge from healing tank":
     @Event playerDealtHealing
     @Condition any([healee.getCurrentHero() == tank_hero for tank_hero in getTankHeroes()])
+    @Condition not eventPlayer.isUsingUltimate()
 
     eventPlayer.missing_ult_points += 0.3*eventHealing
 

--- a/utilities.opy
+++ b/utilities.opy
@@ -4,6 +4,12 @@
 # Macro function for converting decimal to percent
 #!define percent(p) 100*p
 
+# Macro function for converting decimal to percent
+#!define roundedPercent(p) round(100*p)
+
+# Macro function for converting decimal to percent
+#!define percentOf(p, n) p/100*n
+
 #Useful function macros
 #!define heroID(h) getAllHeroes().index(h)
 

--- a/utilities.opy
+++ b/utilities.opy
@@ -5,7 +5,7 @@
 #!define percent(p) 100*p
 
 # Macro function for converting decimal to percent
-#!define roundedPercent(p) round(100*p)
+#!define roundedPercent(p) round(percent(p))
 
 # Macro function for converting decimal to percent
 #!define percentOf(p, n) p/100*n


### PR DESCRIPTION
Shooting/healing tanks now should give ult charge with a margin of error around 2%, that is, if shooting non-tanks give you 30% ult charge, shooting tanks for the same damage will give you 28 to 32% ult charge. Before, the value was closer to 25%.