### PR TITLE
disable support self-healing

### DIFF
--- a/src/main.opy
+++ b/src/main.opy
@@ -7,6 +7,8 @@
 #!include "hp.opy"
 # custom ult charge logic
 #!include "ult_charge.opy"
+# remove support passive
+#!include "support_passive.opy"
 
 # hero specific logic
 #!include "heroes/dva.opy"

--- a/src/support_passive.opy
+++ b/src/support_passive.opy
@@ -1,0 +1,11 @@
+rule "Disable support self-healing passive":
+    @Event playerReceivedHealing
+    # apply to only support heroes
+    @Condition eventPlayer.getCurrentHero() in getSupportHeroes()
+    # apply to self healing (event player heals themselves)
+    @Condition healer == eventPlayer
+    @Condition healee == eventPlayer
+    # apply to passive healing (healing ability source = non-existent)
+    @Condition eventAbility == 0
+
+    damage(eventPlayer, null, eventHealing)


### PR DESCRIPTION
passive healing is detected by checking if the ability source (eventAbility) is null/0

As soon as a support hero receives healing from self-heal, deal damage equal to the amount self healed.