### PR TITLE
Add stun to Cassidy flashbang

### DIFF
--- a/src/base_settings.opy
+++ b/src/base_settings.opy
@@ -76,6 +76,7 @@ settings {
                 "ultGen%": percent(ow2_ult_cost_BRIGITTE/ow1_ult_cost_BRIGITTE)
             },
             "mccree": {
+                "projectileSpeed%": percent(ow1_flashbang_speed/ow2_mag_grenade_speed),
                 "ultGen%": percent(ow2_ult_cost_MCCREE/ow1_ult_cost_MCCREE)
             },
             "dva": {

--- a/src/custom_heroes.opy
+++ b/src/custom_heroes.opy
@@ -2,5 +2,8 @@
 #!include "heroes/dva.opy"
 #!include "heroes/reinhardt.opy"
 #!include "heroes/zarya.opy"
-#!include "heroes/brigitte.opy"
+
+#!include "heroes/mccree.opy"
+
 #!include "heroes/ana.opy"
+#!include "heroes/brigitte.opy"

--- a/src/heroes/brigitte.opy
+++ b/src/heroes/brigitte.opy
@@ -2,6 +2,7 @@
 # see https://workshop.codes/MR5QJ for oreslurpee's 2018 brig implementation
 
 #!include "ow1_constants.opy"
+#!include "ow2_constants.opy"
 
 rule "Add stun to shield bash":
     @Event playerDealtDamage

--- a/src/heroes/mccree.opy
+++ b/src/heroes/mccree.opy
@@ -1,0 +1,21 @@
+#!include "ow1_constants.opy"
+
+playervar flashbang_origin_position
+
+rule "Store flashbang origin position":
+    @Event eachPlayer
+    @Hero mccree
+    @Condition eventPlayer.isUsingAbility2() == true
+    
+    eventPlayer.flashbang_origin_position = eventPlayer.getEyePosition()
+
+rule "Remove magnetic grenade effects":
+    @Event playerTookDamage
+    @Condition attacker.getCurrentHero() == Hero.MCCREE
+    @Condition eventAbility == Button.ABILITY_2
+
+    heal(eventPlayer, null, eventDamage)
+    if distance(eventPlayer.getPosition(), attacker.flashbang_origin_position) <= ow1_flashbang_max_range:
+        eventPlayer.setStatusEffect(attacker, Status.STUNNED, ow1_flashbang_stun_duration)
+    else:
+        eventPlayer.clearStatusEffect(Status.STUNNED)

--- a/src/heroes/mccree.opy
+++ b/src/heroes/mccree.opy
@@ -1,21 +1,49 @@
 #!include "ow1_constants.opy"
 
 playervar flashbang_origin_position
+playervar flashbang_exploded
+
+rule "Disable magnetic grenade":
+    @Event eachPlayer
+    @Hero mccree
+    @Condition eventPlayer.getAbilityCooldown(Button.ABILITY_2) == 0
+
+    eventPlayer.setAbility2Enabled(false)
 
 rule "Store flashbang origin position":
     @Event eachPlayer
     @Hero mccree
     @Condition eventPlayer.isUsingAbility2() == true
-    
-    eventPlayer.flashbang_origin_position = eventPlayer.getEyePosition()
 
-rule "Remove magnetic grenade effects":
+    eventPlayer.flashbang_origin_position = eventPlayer.getEyePosition()
+    eventPlayer.flashbang_exploded = false
+
+rule "Remove all damage from magnetic grenade":
+    @Event eachPlayer
+    @Hero mccree
+    @Condition eventPlayer.isHoldingButton(Button.ABILITY_2) == true
+    @Condition eventPlayer.hasStatusEffect(Status.HACKED) == false
+
+    eventPlayer.setDamageDealt(0.001)
+    eventPlayer.setAbility2Enabled(true)
+    eventPlayer.forceButtonPress(Button.ABILITY_2)
+    eventPlayer.setDamageDealt(100)
+
+rule "Remove all effects from magnetic grenade":
     @Event playerTookDamage
     @Condition attacker.getCurrentHero() == Hero.MCCREE
     @Condition eventAbility == Button.ABILITY_2
 
-    heal(eventPlayer, null, eventDamage)
-    if distance(eventPlayer.getPosition(), attacker.flashbang_origin_position) <= ow1_flashbang_max_range:
-        eventPlayer.setStatusEffect(attacker, Status.STUNNED, ow1_flashbang_stun_duration)
-    else:
-        eventPlayer.clearStatusEffect(Status.STUNNED)
+    heal(eventPlayer, null, eventDamage) # heal all damage inflicted by grenade
+    eventPlayer.clearStatusEffect(Status.STUNNED) # remove any cc inflicted by grenade
+
+rule "Stun flashed enemy":
+    @Event playerTookDamage
+    @Condition attacker.getCurrentHero() == Hero.MCCREE
+    @Condition eventAbility == Button.ABILITY_2
+    @Condition attacker.flashbang_exploded == false # without this the enemy is stunned twice
+    @Condition distance(eventPlayer.getPosition(), attacker.flashbang_origin_position) <= ow1_flashbang_max_range
+
+    damage(eventPlayer, attacker, ow1_flashbang_damage)
+    eventPlayer.setStatusEffect(attacker, Status.STUNNED, ow1_flashbang_stun_duration)
+    attacker.flashbang_exploded = true

--- a/src/ow1_constants.opy
+++ b/src/ow1_constants.opy
@@ -114,6 +114,7 @@
 #!define ow1_flashbang_stun_duration 0.8
 # max range of flashbang is 10m (7m travel + 3m aoe)
 #!define ow1_flashbang_max_range 10
+#!define ow1_flashbang_damage 25
 #!define ow1_shield_bash_stun_duration 0.75
 #!define ow1_sleepdart_sleep_duration 5
 #!define ow1_rally_speed_buff 1.3

--- a/src/ow1_constants.opy
+++ b/src/ow1_constants.opy
@@ -110,6 +110,10 @@
 
 ###################################
 # misc
+#!define ow1_flashbang_speed 30
+#!define ow1_flashbang_stun_duration 0.8
+# max range of flashbang is 10m (7m travel + 3m aoe)
+#!define ow1_flashbang_max_range 10
 #!define ow1_shield_bash_stun_duration 0.75
 #!define ow1_sleepdart_sleep_duration 5
 #!define ow1_rally_speed_buff 1.3

--- a/src/ow2_constants.opy
+++ b/src/ow2_constants.opy
@@ -45,4 +45,5 @@
 ###################################
 # Ammo count
 #!define ow2_ammo_count_GENJI 30
+#!define ow2_mag_grenade_speed 20
 #!define ow2_rally_speed_buff 1.15


### PR DESCRIPTION
resolves #9
The grenade deals 0.001% damage. As soon as a grenade lands on an enemy, the script checks if the enemy is less than 10m (maximum flashable distance in ow1) and stuns them if they are within flashable distance.

Currently, there is no way to clear the "hindered" status effect in workshop (likely because the devs forgot to add this effect to the status list when this effect was introduced in OW2 season 5).

If the "hindered" effect can be cleared, this ability nearly perfectly replicates ow1 flashbang.

Another minor issue is that flashing above reinhardt shield doesn't work.