### PR TITLE
Zarya bubble bug fixes

### DIFF
--- a/src/custom_heroes.opy
+++ b/src/custom_heroes.opy
@@ -7,3 +7,18 @@
 
 #!include "heroes/ana.opy"
 #!include "heroes/brigitte.opy"
+
+rule "reset abilities on new round":
+    @Event eachPlayer
+    @Condition isMatchBetweenRounds() == true
+    
+    waitUntil(eventPlayer.isInSpawnRoom(), 60)
+    eventPlayer.setAbility1Enabled(true)
+    eventPlayer.setAbility2Enabled(true)
+
+rule "reset abilities on hero switch":
+    @Event eachPlayer
+    @Condition eventPlayer.hero_switched == true
+
+    eventPlayer.setAbility1Enabled(true)
+    eventPlayer.setAbility2Enabled(true)

--- a/src/heroes/zarya.opy
+++ b/src/heroes/zarya.opy
@@ -3,7 +3,7 @@
 
 playervar self_bubble_cooldown
 playervar ally_bubble_cooldown
-playervar zarya_hud
+playervar zarya_hud_visibility
 
 rule "create bubble cooldown HUD":
     @Event eachPlayer
@@ -11,7 +11,8 @@ rule "create bubble cooldown HUD":
 
     eventPlayer.self_bubble_cooldown = 0
     eventPlayer.ally_bubble_cooldown = 0
-    createInWorldText(eventPlayer, 
+    eventPlayer.zarya_hud_visibility = eventPlayer
+    createInWorldText(eventPlayer.zarya_hud_visibility, 
                       "{0}    {1}".format(ceil(eventPlayer.self_bubble_cooldown), ceil(eventPlayer.ally_bubble_cooldown)), 
                       updateEveryTick(eventPlayer.getEyePosition() + (100 * (2.15 * worldVector(Vector.RIGHT, eventPlayer, Transform.ROTATION) + ((-1.45 - 0.2) * (angleToDirection(horizontalAngleOfDirection(eventPlayer.getFacingDirection()), 
                       verticalAngleOfDirection(eventPlayer.getFacingDirection()) - 90))) + 3 * eventPlayer.getFacingDirection()))), 
@@ -20,14 +21,13 @@ rule "create bubble cooldown HUD":
                       WorldTextReeval.VISIBILITY_POSITION_STRING_AND_COLOR, 
                       Color.WHITE, 
                       SpecVisibility.DEFAULT)
-    eventPlayer.zarya_hud = getLastCreatedText()
 
 rule "destroy bubble cooldown HUD":
     @Event eachPlayer
     @Condition eventPlayer.hero_switched == true
     @Condition eventPlayer.getCurrentHero() != Hero.ZARYA
 
-    destroyInWorldText(eventPlayer.zarya_hud)
+    eventPlayer.zarya_hud_visibility = null
     eventPlayer.setAbility1Enabled(true)
     eventPlayer.setAbility2Enabled(true)
   

--- a/src/heroes/zarya.opy
+++ b/src/heroes/zarya.opy
@@ -28,9 +28,7 @@ rule "destroy bubble cooldown HUD":
     @Condition eventPlayer.getCurrentHero() != Hero.ZARYA
 
     eventPlayer.zarya_hud_visibility = null
-    eventPlayer.setAbility1Enabled(true)
-    eventPlayer.setAbility2Enabled(true)
-  
+
 rule "zarya self bubble":
     @Event eachPlayer
     @Hero zarya


### PR DESCRIPTION
Fixes #57 and #58 

Bubble HUD visibility is controlled by setting the visibile to players (stored in player variable) instead of destroying the HUD.
For cases when zarya uses bubble right as round ends, ability1 and ability2 are reanabled when the player is inside the spawn room.