### PR TITLE
OW1 doomfist reenabled

### DIFF
--- a/src/base_settings.opy
+++ b/src/base_settings.opy
@@ -79,6 +79,14 @@ settings {
                 "projectileSpeed%": percent(ow1_flashbang_speed/ow2_mag_grenade_speed),
                 "ultGen%": percent(ow2_ult_cost_MCCREE/ow1_ult_cost_MCCREE)
             },
+            "doomfist": {
+                "ammoRegenerationTime%": 135,
+                "ultKb%": 300,
+                "ability1ChargeRate%": 10,
+                "secondaryFireKb%": 115,
+                "ultDuration%": 150,
+                "ultGen%": percent(ow2_ult_cost_DOOMFIST/ow1_ult_cost_DOOMFIST)
+            },
             "dva": {
                 "secondaryFireMaximumTime%": 67,
                 "ability2Cooldown%": 114,
@@ -115,14 +123,6 @@ settings {
             },
             "reaper": {
                 "ultGen%": percent(ow2_ult_cost_REAPER/ow1_ult_cost_REAPER)
-            },
-            "doomfist": {
-                "ammoRegenerationTime%": 135,
-                "ultKb%": 300,
-                "ability1ChargeRate%": 10,
-                "secondaryFireKb%": 115,
-                "ultDuration%": 150,
-                "ultGen%": percent(ow2_ult_cost_DOOMFIST/ow1_ult_cost_DOOMFIST)
             },
             "reinhardt": {
                 "secondaryFireRechargeRate%": 139,

--- a/src/base_settings.opy
+++ b/src/base_settings.opy
@@ -116,6 +116,14 @@ settings {
             "reaper": {
                 "ultGen%": percent(ow2_ult_cost_REAPER/ow1_ult_cost_REAPER)
             },
+            "doomfist": {
+                "ammoRegenerationTime%": 135,
+                "ultKb%": 300,
+                "ability1ChargeRate%": 10,
+                "secondaryFireKb%": 115,
+                "ultDuration%": 150,
+                "ultGen%": percent(ow2_ult_cost_DOOMFIST/ow1_ult_cost_DOOMFIST)
+            },
             "reinhardt": {
                 "secondaryFireRechargeRate%": 139,
                 "ability1Cooldown%": 143,
@@ -170,7 +178,6 @@ settings {
                 "ultGen%": percent(ow2_ult_cost_ZENYATTA/ow1_ult_cost_ZENYATTA)
             },
             "disabledHeroes": [
-                "doomfist",
                 "junkerQueen",
                 "kiriko",
                 "lifeweaver",

--- a/src/custom_heroes.opy
+++ b/src/custom_heroes.opy
@@ -7,11 +7,7 @@
 
 #!include "heroes/ana.opy"
 #!include "heroes/brigitte.opy"
-<<<<<<< Updated upstream
-=======
-#!include "heroes/bastion.opy"
 #!include "heroes/doomfist.opy"
->>>>>>> Stashed changes
 
 rule "reset abilities on new round":
     @Event eachPlayer

--- a/src/custom_heroes.opy
+++ b/src/custom_heroes.opy
@@ -7,6 +7,11 @@
 
 #!include "heroes/ana.opy"
 #!include "heroes/brigitte.opy"
+<<<<<<< Updated upstream
+=======
+#!include "heroes/bastion.opy"
+#!include "heroes/doomfist.opy"
+>>>>>>> Stashed changes
 
 rule "reset abilities on new round":
     @Event eachPlayer

--- a/src/custom_heroes.opy
+++ b/src/custom_heroes.opy
@@ -1,4 +1,5 @@
 # hero specific logic
+#!include "heroes/doomfist.opy"
 #!include "heroes/dva.opy"
 #!include "heroes/reinhardt.opy"
 #!include "heroes/zarya.opy"
@@ -7,7 +8,7 @@
 
 #!include "heroes/ana.opy"
 #!include "heroes/brigitte.opy"
-#!include "heroes/doomfist.opy"
+
 
 rule "reset abilities on new round":
     @Event eachPlayer

--- a/src/heroes/doomfist.opy
+++ b/src/heroes/doomfist.opy
@@ -1,0 +1,138 @@
+#!include "ow2_constants.opy"
+
+
+rule "Doom shields":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.getHealthOfType(Health.SHIELDS) == 100
+    
+    eventPlayer.setStatusEffect(eventPlayer, Status.UNKILLABLE, 9999)
+
+
+rule "Doom shields":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.getHealthOfType(Health.SHIELDS) < 100
+    
+    eventPlayer.clearStatusEffect(Status.UNKILLABLE)
+
+
+rule "Speed":
+    @Event playerDealtDamage
+    @Hero doomfist
+    @Condition eventPlayer.isUsingAbility1() == true
+    
+    victim.setMoveSpeed(95)
+    wait(2.5)
+    victim.setMoveSpeed(100)
+
+
+rule "Knockback":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition isGameInProgress() == true
+    
+    eventPlayer.setKnockbackReceived(130)
+
+
+rule "More Knockback":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.isUsingAbility1() == true
+    
+    eventPlayer.applyImpulse(Vector.DOWN, 10, Relativity.TO_WORLD, Impulse.INCORPORATE_CONTRARY_MOTION)
+    wait(0.45)
+
+
+rule "Upper cut":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.isUsingAbility2() == true
+    
+    eventPlayer.applyImpulse(Vector.UP, 15, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION)
+    getPlayersInRadius(eventPlayer, 5, getOppositeTeam(eventPlayer.getTeam()), LosCheck.OFF).applyImpulse(Vector.UP, 15, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION)
+    #getPlayersInRadius(eventPlayer, 5, getOppositeTeam(eventPlayer.getTeam()), LosCheck.OFF).setStatusEffect(eventPlayer, Status.STUNNED, 1.25)
+    damage(getPlayersInRadius(eventPlayer, 5, getOppositeTeam(eventPlayer.getTeam()), LosCheck.OFF), eventPlayer, 50)
+    getPlayersInRadius(eventPlayer, 5, getOppositeTeam(eventPlayer.getTeam()), LosCheck.OFF).setMoveSpeed(0)
+    eventPlayer.cancelPrimaryAction()
+    wait(0.95)
+    eventPlayer.setGravity(0)
+    getPlayersInRadius(eventPlayer, 5, getOppositeTeam(eventPlayer.getTeam()), LosCheck.OFF).setStatusEffect(eventPlayer, Status.ROOTED, 0.6)
+    getPlayersInRadius(eventPlayer, 5, getOppositeTeam(eventPlayer.getTeam()), LosCheck.OFF).setGravity(0)
+    wait(0.6)
+    getAllPlayers().setGravity(100)
+    getAllPlayers().setMoveSpeed(100)
+
+
+rule "DOOMS FIST":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.isFiringSecondaryFire() == true
+    
+    eventPlayer.setDamageDealt(370)
+    wait(0.15)
+    eventPlayer.setDamageDealt(370)
+    wait(0.15)
+
+
+rule "DOOMS FIST":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.isFiringSecondaryFire() == false
+    
+    eventPlayer.setDamageDealt(100)
+
+
+rule "Sismic":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.isUsingAbility1() == true
+    
+    eventPlayer.setDamageDealt(50)
+    hudHeader(eventPlayer, "[25]", HudPosition.TOP, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+    wait(0.25, Wait.ABORT_WHEN_FALSE)
+    eventPlayer.setDamageDealt(100)
+    destroyHudText(getLastCreatedText())
+    hudHeader(eventPlayer, "[50]", HudPosition.TOP, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+    wait(0.25, Wait.ABORT_WHEN_FALSE)
+    eventPlayer.setDamageDealt(150)
+    destroyHudText(getLastCreatedText())
+    hudHeader(eventPlayer, "[75]", HudPosition.TOP, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+    wait(0.25, Wait.ABORT_WHEN_FALSE)
+    eventPlayer.setDamageDealt(200)
+    destroyHudText(getLastCreatedText())
+    hudHeader(eventPlayer, "[100]", HudPosition.TOP, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+    wait(0.25, Wait.ABORT_WHEN_FALSE)
+    eventPlayer.setDamageDealt(250)
+    destroyHudText(getLastCreatedText())
+    hudHeader(eventPlayer, "[125]", HudPosition.TOP, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+
+
+rule "Slam":
+    @Event eachPlayer
+    @Hero doomfist
+    @Condition eventPlayer.isUsingAbility1() == false
+    
+    eventPlayer.setDamageDealt(100)
+    destroyAllHudTexts()
+    destroyAllHudTexts()
+    wait(0.25)
+    destroyAllHudTexts()
+    wait(0.25)
+    destroyAllHudTexts()
+    wait(0.25)
+    destroyAllHudTexts()
+    wait(0.25)
+    destroyAllHudTexts()
+    wait(0.25)
+    destroyAllHudTexts()
+    wait(0.25)
+    destroyAllHudTexts()
+
+
+
+
+
+
+ 
+    

--- a/src/heroes/doomfist.opy
+++ b/src/heroes/doomfist.opy
@@ -1,22 +1,5 @@
 #!include "ow2_constants.opy"
 
-
-rule "Doom shields":
-    @Event eachPlayer
-    @Hero doomfist
-    @Condition eventPlayer.getHealthOfType(Health.SHIELDS) == 100
-    
-    eventPlayer.setStatusEffect(eventPlayer, Status.UNKILLABLE, 9999)
-
-
-rule "Doom shields":
-    @Event eachPlayer
-    @Hero doomfist
-    @Condition eventPlayer.getHealthOfType(Health.SHIELDS) < 100
-    
-    eventPlayer.clearStatusEffect(Status.UNKILLABLE)
-
-
 rule "Speed":
     @Event playerDealtDamage
     @Hero doomfist

--- a/src/hp.opy
+++ b/src/hp.opy
@@ -31,6 +31,7 @@ rule "initialize overwatch 1 hero healths":
     hero_health_normal[heroID(Hero.REAPER)] = ow1_health_normal_REAPER
     hero_health_normal[heroID(Hero.SOLDIER)] = ow1_health_normal_SOLDIER
     hero_health_normal[heroID(Hero.SOMBRA)] = ow1_health_normal_SOMBRA
+    hero_health_normal[heroID(Hero.DOOMFIST)] = ow1_health_normal_DOOMFIST
     hero_health_normal[heroID(Hero.SYMMETRA)] = ow1_health_normal_SYMMETRA
     hero_health_normal[heroID(Hero.TORBJORN)] = ow1_health_normal_TORBJORN
     hero_health_normal[heroID(Hero.TRACER)] = ow1_health_normal_TRACER

--- a/src/ow1_constants.opy
+++ b/src/ow1_constants.opy
@@ -7,6 +7,7 @@
 #!define ow1_ult_cost_WINSTON 1540
 #!define ow1_ult_cost_HAMMOND 1540
 #!define ow1_ult_cost_ZARYA 2100
+#!define ow1_ult_cost_DOOMFIST 1680
 
 #!define ow1_ult_cost_ASHE 2240
 #!define ow1_ult_cost_BASTION 2310
@@ -42,6 +43,7 @@
 #!define ow1_health_normal_WINSTON 350
 #!define ow1_health_normal_HAMMOND 500
 #!define ow1_health_normal_ZARYA 200
+#!define ow1_health_normal_DOOMFIST 250
 
 #!define ow1_health_normal_ASHE 0
 #!define ow1_health_normal_BASTION 0

--- a/src/ow2_constants.opy
+++ b/src/ow2_constants.opy
@@ -7,6 +7,7 @@
 #!define ow2_ult_cost_WINSTON 1850
 #!define ow2_ult_cost_HAMMOND 1675
 #!define ow2_ult_cost_ZARYA 2270
+#!define ow2_ult_cost_DOOMFIST 1680
 
 #!define ow2_ult_cost_ASHE 2240
 #!define ow2_ult_cost_BASTION 2310

--- a/src/ult_charge.opy
+++ b/src/ult_charge.opy
@@ -21,6 +21,7 @@ rule "initialize overwatch 1 ultimate costs":
     ult_cost[heroID(Hero.ASHE)] = 1/(roundedPercent(ow2_ult_cost_ASHE/ow1_ult_cost_ASHE)/100)*ow2_ult_cost_ASHE
     ult_cost[heroID(Hero.BASTION)] = 1/(roundedPercent(ow2_ult_cost_BASTION/ow1_ult_cost_BASTION)/100)*ow2_ult_cost_BASTION
     ult_cost[heroID(Hero.MCCREE)] = 1/(roundedPercent(ow2_ult_cost_MCCREE/ow1_ult_cost_MCCREE)/100)*ow2_ult_cost_MCCREE
+    ult_cost[heroID(Hero.DOOMFIST)] = 1/(roundedPercent(ow2_ult_cost_DOOMFIST/ow1_ult_cost_DOOMFIST)/100)*ow2_ult_cost_DOOMFIST
     ult_cost[heroID(Hero.ECHO)] = 1/(roundedPercent(ow2_ult_cost_ECHO/ow1_ult_cost_ECHO)/100)*ow2_ult_cost_ECHO
     ult_cost[heroID(Hero.GENJI)] = 1/(roundedPercent(ow2_ult_cost_GENJI/ow1_ult_cost_GENJI)/100)*ow2_ult_cost_GENJI
     ult_cost[heroID(Hero.HANZO)] = 1/(roundedPercent(ow2_ult_cost_HANZO/ow1_ult_cost_HANZO)/100)*ow2_ult_cost_HANZO


### PR DESCRIPTION
Modified health and abilities to mimic OW1 doomfist. Resolves #39 

Doomfist's slam and uppercut keybinds are swapped for now.