### PR TITLE
OW1 Mercy Guardian Angel (shift) recreation v1

### DIFF
--- a/src/custom_heroes.opy
+++ b/src/custom_heroes.opy
@@ -7,6 +7,7 @@
 
 #!include "heroes/ana.opy"
 #!include "heroes/brigitte.opy"
+#!include "heroes/mercy.opy"
 
 rule "reset abilities on new round":
     @Event eachPlayer

--- a/src/heroes/mercy.opy
+++ b/src/heroes/mercy.opy
@@ -1,0 +1,47 @@
+#!include "ow1_constants.opy"
+
+playervar slingshot_initial_velocity
+
+rule "[mercy.opy]: Disable jump and crouch while guardian angel":
+    @Event eachPlayer
+    @Hero mercy
+    @Condition eventPlayer.isUsingAbility1() == true
+    
+    eventPlayer.disallowButton(Button.JUMP)
+    eventPlayer.disallowButton(Button.CROUCH)
+    waitUntil(not eventPlayer.isHoldingButton(Button.ABILITY_1), 10)
+    eventPlayer.allowButton(Button.JUMP)
+    eventPlayer.allowButton(Button.CROUCH)
+
+def startSlingshot():
+    eventPlayer.setAbility1Enabled(false) # disable GA during slinshot
+    eventPlayer.startForcingButton(Button.JUMP) # start angelic descent
+    eventPlayer.applyImpulse(eventPlayer.slingshot_initial_velocity, magnitude(eventPlayer.slingshot_initial_velocity), Relativity.TO_WORLD, Impulse.INCORPORATE_CONTRARY_MOTION)
+    waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), 10)
+    eventPlayer.stopForcingButton(Button.JUMP)
+    eventPlayer.setAbility1Enabled(true)
+
+rule "[mercy.opy]: Custom GA + jump combo logic":
+    @Event eachPlayer
+    @Hero mercy
+    @Condition eventPlayer.isUsingAbility1() == true
+    @Condition eventPlayer.isHoldingButton(Button.JUMP) == true
+    
+    eventPlayer.slingshot_initial_velocity = eventPlayer.getVelocity() + jump_velocity
+    eventPlayer.forceButtonPress(Button.ABILITY_1) # interrupt GA
+    wait() # wait for GA meter to clear
+    startSlingshot()
+
+# rule "[mercy.opy]: Force angelic descent when holding jump":
+#     @Event eachPlayer
+#     @Hero mercy
+#     @Condition eventPlayer.isHoldingButton(Button.JUMP) == true
+
+#     eventPlayer.forceButtonPress(Button.JUMP)
+
+# rule "[mercy.opy]: Exit angelic descent when releasing jump":
+#     @Event eachPlayer
+#     @Hero mercy
+#     @Condition eventPlayer.isHoldingButton(Button.JUMP) == false
+
+#     eventPlayer.stopForcingButton(Button.JUMP)

--- a/src/heroes/mercy.opy
+++ b/src/heroes/mercy.opy
@@ -39,7 +39,7 @@ rule "[mercy.opy]: Execute slingshot":
 
     eventPlayer.slingshot_initial_velocity = eventPlayer.getVelocity() + jump_velocity
     if eventPlayer.isHoldingButton(Button.CROUCH): # add extra jump momentum for superjump
-        eventPlayer.slingshot_initial_velocity += 0.25*eventPlayer.getVelocity()
+        eventPlayer.slingshot_initial_velocity += eventPlayer.getVelocity()/3
     eventPlayer.forceButtonPress(Button.ABILITY_1) # interrupt GA
     wait() # wait for OW2 GA meter to clear
     startSlingshot()

--- a/src/heroes/mercy.opy
+++ b/src/heroes/mercy.opy
@@ -38,7 +38,7 @@ rule "[mercy.opy]: Execute slingshot":
     @Condition eventPlayer.slingshotting == true
 
     eventPlayer.slingshot_initial_velocity = eventPlayer.getVelocity() + jump_velocity
-    if eventPlayer.isHoldingButton(Button.CROUCH): # add extra jump momentum for superjump
+    if eventPlayer.isHoldingButton(Button.CROUCH): # add extra vertical momentum for superjump
         eventPlayer.slingshot_initial_velocity += eventPlayer.getVelocity()/3
     eventPlayer.forceButtonPress(Button.ABILITY_1) # interrupt GA
     wait() # wait for OW2 GA meter to clear

--- a/src/heroes/mercy.opy
+++ b/src/heroes/mercy.opy
@@ -18,7 +18,7 @@ def startSlingshot():
     eventPlayer.applyImpulse(eventPlayer.slingshot_initial_velocity, magnitude(eventPlayer.slingshot_initial_velocity), Relativity.TO_WORLD, Impulse.INCORPORATE_CONTRARY_MOTION)
     eventPlayer.allowButton(Button.JUMP)
     eventPlayer.startForcingButton(Button.JUMP) # start angelic descent
-    waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), 10)
+    waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), 99999)
     eventPlayer.stopForcingButton(Button.JUMP)
     eventPlayer.slingshotting = false
 

--- a/src/heroes/mercy.opy
+++ b/src/heroes/mercy.opy
@@ -15,6 +15,7 @@ rule "[mercy.opy]: Disable jump and crouch while guardian angel":
 
 def startSlingshot():
     eventPlayer.setAbility1Enabled(false) # disable GA during slinshot
+    eventPlayer.allowButton(Button.JUMP)
     eventPlayer.startForcingButton(Button.JUMP) # start angelic descent
     eventPlayer.applyImpulse(eventPlayer.slingshot_initial_velocity, magnitude(eventPlayer.slingshot_initial_velocity), Relativity.TO_WORLD, Impulse.INCORPORATE_CONTRARY_MOTION)
     waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), 10)

--- a/src/heroes/mercy.opy
+++ b/src/heroes/mercy.opy
@@ -14,13 +14,11 @@ rule "[mercy.opy]: Disable jump and crouch while guardian angel":
     eventPlayer.allowButton(Button.CROUCH)
 
 def startSlingshot():
-    eventPlayer.setAbility1Enabled(false) # disable GA during slinshot
+    eventPlayer.applyImpulse(eventPlayer.slingshot_initial_velocity, magnitude(eventPlayer.slingshot_initial_velocity), Relativity.TO_WORLD, Impulse.INCORPORATE_CONTRARY_MOTION)
     eventPlayer.allowButton(Button.JUMP)
     eventPlayer.startForcingButton(Button.JUMP) # start angelic descent
-    eventPlayer.applyImpulse(eventPlayer.slingshot_initial_velocity, magnitude(eventPlayer.slingshot_initial_velocity), Relativity.TO_WORLD, Impulse.INCORPORATE_CONTRARY_MOTION)
     waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), 10)
     eventPlayer.stopForcingButton(Button.JUMP)
-    eventPlayer.setAbility1Enabled(true)
 
 rule "[mercy.opy]: Custom GA + jump combo logic":
     @Event eachPlayer
@@ -33,16 +31,15 @@ rule "[mercy.opy]: Custom GA + jump combo logic":
     wait() # wait for GA meter to clear
     startSlingshot()
 
-# rule "[mercy.opy]: Force angelic descent when holding jump":
-#     @Event eachPlayer
-#     @Hero mercy
-#     @Condition eventPlayer.isHoldingButton(Button.JUMP) == true
+rule "[mercy.opy]: Slingshot GA cooldown logic":
+    @Event eachPlayer
+    @Hero mercy
+    @Condition eventPlayer.isUsingAbility1() == true
+    @Condition eventPlayer.isHoldingButton(Button.JUMP) == false
 
-#     eventPlayer.forceButtonPress(Button.JUMP)
-
-# rule "[mercy.opy]: Exit angelic descent when releasing jump":
-#     @Event eachPlayer
-#     @Hero mercy
-#     @Condition eventPlayer.isHoldingButton(Button.JUMP) == false
-
-#     eventPlayer.stopForcingButton(Button.JUMP)
+    waitUntil(eventPlayer.isHoldingButton(Button.JUMP), 10)
+    if eventPlayer.isHoldingButton(Button.JUMP):
+        eventPlayer.setAbility1Enabled(false)
+        waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), ow1_mercy_guardian_angel_recovery_time)
+        eventPlayer.setAbilityCooldown(Button.ABILITY_1, ow1_cooldown_ability1_MERCY)
+        eventPlayer.setAbility1Enabled(true)

--- a/src/heroes/mercy.opy
+++ b/src/heroes/mercy.opy
@@ -1,6 +1,7 @@
 #!include "ow1_constants.opy"
 
 playervar slingshot_initial_velocity
+playervar slingshotting
 
 rule "[mercy.opy]: Disable jump and crouch while guardian angel":
     @Event eachPlayer
@@ -9,7 +10,7 @@ rule "[mercy.opy]: Disable jump and crouch while guardian angel":
     
     eventPlayer.disallowButton(Button.JUMP)
     eventPlayer.disallowButton(Button.CROUCH)
-    waitUntil(not eventPlayer.isHoldingButton(Button.ABILITY_1), 10)
+    waitUntil(not eventPlayer.isUsingAbility1(), 10)
     eventPlayer.allowButton(Button.JUMP)
     eventPlayer.allowButton(Button.CROUCH)
 
@@ -19,27 +20,36 @@ def startSlingshot():
     eventPlayer.startForcingButton(Button.JUMP) # start angelic descent
     waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), 10)
     eventPlayer.stopForcingButton(Button.JUMP)
+    eventPlayer.slingshotting = false
 
-rule "[mercy.opy]: Custom GA + jump combo logic":
+rule "[mercy.opy]: Detect slingshot":
     @Event eachPlayer
     @Hero mercy
     @Condition eventPlayer.isUsingAbility1() == true
-    @Condition eventPlayer.isHoldingButton(Button.JUMP) == true
-    
+    @Condition eventPlayer.slingshotting == false
+
+    waitUntil(eventPlayer.isHoldingButton(Button.JUMP), 10)
+    if eventPlayer.isHoldingButton(Button.JUMP):
+        eventPlayer.slingshotting = true
+
+rule "[mercy.opy]: Execute slingshot":
+    @Event eachPlayer
+    @Hero mercy
+    @Condition eventPlayer.slingshotting == true
+
     eventPlayer.slingshot_initial_velocity = eventPlayer.getVelocity() + jump_velocity
+    if eventPlayer.isHoldingButton(Button.CROUCH): # add extra jump momentum for superjump
+        eventPlayer.slingshot_initial_velocity += 0.25*eventPlayer.getVelocity()
     eventPlayer.forceButtonPress(Button.ABILITY_1) # interrupt GA
-    wait() # wait for GA meter to clear
+    wait() # wait for OW2 GA meter to clear
     startSlingshot()
 
 rule "[mercy.opy]: Slingshot GA cooldown logic":
     @Event eachPlayer
     @Hero mercy
-    @Condition eventPlayer.isUsingAbility1() == true
-    @Condition eventPlayer.isHoldingButton(Button.JUMP) == false
+    @Condition eventPlayer.slingshotting == true
 
-    waitUntil(eventPlayer.isHoldingButton(Button.JUMP), 10)
-    if eventPlayer.isHoldingButton(Button.JUMP):
-        eventPlayer.setAbility1Enabled(false)
-        waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), ow1_mercy_guardian_angel_recovery_time)
-        eventPlayer.setAbilityCooldown(Button.ABILITY_1, ow1_cooldown_ability1_MERCY)
-        eventPlayer.setAbility1Enabled(true)
+    eventPlayer.setAbility1Enabled(false)
+    waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), ow1_mercy_guardian_angel_recovery_time)
+    eventPlayer.setAbilityCooldown(Button.ABILITY_1, ow1_cooldown_ability1_MERCY)
+    eventPlayer.setAbility1Enabled(true)

--- a/src/ow1_constants.opy
+++ b/src/ow1_constants.opy
@@ -107,9 +107,11 @@
 #!define ow1_cooldown_ability1_ZARYA 10
 #!define ow1_cooldown_ability2_ZARYA 8
 #!define ow1_cooldown_ability2_REINHARDT 6
+#!define ow1_cooldown_ability1_MERCY 1.5
 
 ###################################
 # misc
+#!define jump_velocity vect(0, 5.44, 0)
 #!define ow1_flashbang_speed 30
 #!define ow1_flashbang_stun_duration 0.8
 # max range of flashbang is 10m (7m travel + 3m aoe)
@@ -120,3 +122,4 @@
 #!define ow1_rally_speed_buff 1.3
 # ana dart damage should be 70, but extra 2 dmg needed for shoot nade shoot combo
 #!define ow1_ana_dart_damage 72
+#!define ow1_mercy_guardian_angel_recovery_time 1


### PR DESCRIPTION
Resolves #67 

Native OW2 GA logic is first disabled by disallowing jump and crouch key during GA.

The workshop script detects when the player is holding jump key during GA. When jump key is detected during GA, the current velocity (speed and direction) is saved and the mercy player is pushed into the direction of the saved velocity (+ velocity of jumping) while holding jump key. This mechanism is commonly referred to as "slingshotting".

"Superjump" (GA + crouch + space) is actually a special case of "slingshotting". When the mercy holds crouch right before GA, she dips lower then rises back up near the end of GA. This rising up action provides the upwards momentum during "slingshotting". As a result, no special logic was needed to implement superjump.

Currently, holding crouch before slingshotting multiplies the saved velocity by 1.333. This 33.3% bonus was selected based on trial and error. However, this method of providing bonus momentum when crouched can be easily abused to achieve super-slingshot (activated by performing regular slingshot with crouch).