### PR TITLE
Add mei freeze (resolves make mei primary fire freeze #48):

### DIFF
--- a/src/constants/ow1_constants.opy
+++ b/src/constants/ow1_constants.opy
@@ -158,6 +158,9 @@
 #!define OW1_GENJI_CLIP_SIZE 30
 #!define OW1_GENJI_SHURIKEN_DAMAGE 29
 
+# Mei
+#!define OW1_MEI_CLIP_SIZE 120
+
 # Mercy
 #!define OW1_MERCY_CLIP_SIZE 20
 

--- a/src/ow1/heroes/heroes.opy
+++ b/src/ow1/heroes/heroes.opy
@@ -15,6 +15,7 @@
 #!include "ow1/heroes/bastion.opy"
 #!include "ow1/heroes/genji.opy"
 #!include "ow1/heroes/mccree.opy"
+#!include "ow1/heroes/mei.opy"
 #!include "ow1/heroes/symmetra.opy"
 #!include "ow1/heroes/tracer.opy"
 

--- a/src/ow1/heroes/mei.opy
+++ b/src/ow1/heroes/mei.opy
@@ -1,12 +1,20 @@
 #!mainFile "../../main.opy"
 
-def initBaptiste():
-    # [TODO]
-    pass
+def initMei():
+    eventPlayer.setAmmo(0, OW1_MEI_CLIP_SIZE)
+    eventPlayer.setMaxAmmo(0, OW1_MEI_CLIP_SIZE)
 
-rule "[ashe.opy]: Initialize Baptiste":
+rule "[mei.opy]: Initialize Mei":
     @Event eachPlayer
-    @Hero baptiste
+    @Hero mei
     @Condition eventPlayer.reset_flag == true # without this flag, the reset code in generic.opy executes after initialization
 
-    initBaptiste()
+    initMei()
+
+rule "[mei.opy] Freeze enemy": # credit to snappycreeper for this rule
+    @Event playerDealtDamage
+    @Hero mei
+    @Condition eventPlayer.isFiringPrimaryFire() == true
+    
+    wait(1.5, Wait.ABORT_WHEN_FALSE)
+    victim.setStatusEffect(eventPlayer, Status.FROZEN, 1.5)


### PR DESCRIPTION
This freeze logic is based on dealing uninterrupted damage for 1.5 seconds. May get updated to more sophisticated logic in the future.