### PR TITLE
Recreate OW1 Cassidy flashbang

### DIFF
--- a/src/constants/ow1_constants.opy
+++ b/src/constants/ow1_constants.opy
@@ -108,11 +108,6 @@
 
 ###################################
 # misc
-#!define ow1_flashbang_speed 30
-#!define ow1_flashbang_stun_duration 0.8
-# max range of flashbang is 10m (7m travel + 3m aoe)
-#!define ow1_flashbang_max_range 10
-#!define ow1_flashbang_damage 25
 #!define ow1_shield_bash_stun_duration 0.75
 #!define ow1_sleepdart_sleep_duration 5
 #!define ow1_rally_speed_buff 1.3
@@ -157,6 +152,14 @@
 # Genji
 #!define OW1_GENJI_CLIP_SIZE 30
 #!define OW1_GENJI_SHURIKEN_DAMAGE 29
+
+# Mccree
+#!define OW1_MCCREE_FLASHBANG_RADIUS 3
+#!define ow1_flashbang_speed 30
+#!define ow1_flashbang_stun_duration 0.8
+#!define ow1_flashbang_max_range 7
+#!define ow1_flashbang_damage 25
+#!define OW1_MCCREE_FLASHBANG_COOLDOWN 10
 
 # Mei
 #!define OW1_MEI_CLIP_SIZE 120

--- a/src/constants/ow1_constants.opy
+++ b/src/constants/ow1_constants.opy
@@ -154,12 +154,12 @@
 #!define OW1_GENJI_SHURIKEN_DAMAGE 29
 
 # Mccree
-#!define OW1_MCCREE_FLASHBANG_RADIUS 3
-#!define ow1_flashbang_speed 30
-#!define ow1_flashbang_stun_duration 0.8
-#!define ow1_flashbang_max_range 7
-#!define ow1_flashbang_damage 25
+#!define OW1_MCCREE_FLASHBANG_DAMAGE 25
+#!define OW1_MCCREE_FLASHBANG_AOE_RADIUS 3
+#!define OW1_MCCREE_FLASHBANG_SPEED 30
+#!define OW1_MCCREE_FLASHBANG_RANGE 7
 #!define OW1_MCCREE_FLASHBANG_COOLDOWN 10
+#!define OW1_MCCREE_FLASHBANG_STUN_DURATION 0.8
 
 # Mei
 #!define OW1_MEI_CLIP_SIZE 120

--- a/src/ow1/heroes/mccree.opy
+++ b/src/ow1/heroes/mccree.opy
@@ -4,7 +4,7 @@ playervar flashbang_origin_position
 playervar flashbang_exploded
 
 def initMccree():
-    eventPlayer.setAbility2Enabled(false)
+    eventPlayer.disallowButton(Button.ABILITY_2)
 
 rule "[mccree.opy]: Initialize Mccree":
     @Event eachPlayer

--- a/src/ow1/heroes/mccree.opy
+++ b/src/ow1/heroes/mccree.opy
@@ -4,7 +4,7 @@ playervar flashbang_origin_position
 playervar flashbang_exploded
 
 def initMccree():
-    eventPlayer.setProjectileSpeed(percent(ow1_flashbang_speed/ow2_mag_grenade_speed))
+    eventPlayer.setAbility2Enabled(false)
 
 rule "[mccree.opy]: Initialize Mccree":
     @Event eachPlayer
@@ -13,48 +13,20 @@ rule "[mccree.opy]: Initialize Mccree":
 
     initMccree()
 
-rule "Disable magnetic grenade":
+rule "[mccree.opy]: Throw projectile when pressing e":
     @Event eachPlayer
     @Hero mccree
-    @Condition eventPlayer.getAbilityCooldown(Button.ABILITY_2) == 0
+    @Condition eventPlayer.isHoldingButton(Button.ABILITY_2)
+    @Condition eventPlayer.getAbilityCooldown(Button.ABILITY_2) <= 0
+    @Condition not eventPlayer.isUsingAbility1() # Ensure Cassidy is not rolling
+    @Condition not eventPlayer.hasStatusEffect(Status.HACKED) # Ensure Cassidy is not hacked
 
-    eventPlayer.setAbility2Enabled(false)
+    createProjectile(Projectile.PHARAH_ROCKET, eventPlayer, null, null, Relativity.TO_WORLD, ModifyHealth.DAMAGE, getOppositeTeam(eventPlayer.getTeam()), 25, 1, 3, DynamicEffect.BAD_EXPLOSION, DynamicEffect.MCCREE_FLASHBANG_EXPLOSION_SOUND, 0, 30, 0.233, 0, 0, 1)
+    eventPlayer.setAbilityCooldown(Button.ABILITY_2, OW1_MCCREE_FLASHBANG_COOLDOWN)
 
-rule "Store flashbang origin position":
-    @Event eachPlayer
-    @Hero mccree
-    @Condition eventPlayer.isUsingAbility2() == true
-
-    eventPlayer.flashbang_origin_position = eventPlayer.getEyePosition()
-    eventPlayer.flashbang_exploded = false
-
-rule "Remove all damage from magnetic grenade":
-    @Event eachPlayer
-    @Hero mccree
-    @Condition eventPlayer.isHoldingButton(Button.ABILITY_2) == true
-    @Condition eventPlayer.hasStatusEffect(Status.HACKED) == false
-
-    eventPlayer.setDamageDealt(0.001)
-    eventPlayer.setAbility2Enabled(true)
-    eventPlayer.forceButtonPress(Button.ABILITY_2)
-    eventPlayer.setDamageDealt(100)
-
-rule "Remove all effects from magnetic grenade":
+rule "[mccree.opy]: Stun flashed enemy":
     @Event playerTookDamage
-    @Condition attacker.getCurrentHero() == Hero.MCCREE
-    @Condition eventAbility == Button.ABILITY_2
+    @Condition eventAbility == 0
+    @Condition attacker.getCurrentHero() == Hero.MCCREE or attacker.getCurrentHero() == Hero.GENJI
 
-    heal(eventPlayer, null, eventDamage) # heal all damage inflicted by grenade
-    eventPlayer.clearStatusEffect(Status.STUNNED) # remove any cc inflicted by grenade
-
-rule "Stun flashed enemy":
-    @Event playerTookDamage
-    @Condition attacker.getCurrentHero() == Hero.MCCREE
-    @Condition victim != attacker
-    @Condition eventAbility == Button.ABILITY_2
-    @Condition attacker.flashbang_exploded == false # without this the enemy is stunned twice
-    @Condition distance(eventPlayer.getPosition(), attacker.flashbang_origin_position) <= ow1_flashbang_max_range
-
-    damage(eventPlayer, attacker, ow1_flashbang_damage)
-    eventPlayer.setStatusEffect(attacker, Status.STUNNED, ow1_flashbang_stun_duration)
-    attacker.flashbang_exploded = true
+    victim.setStatusEffect(eventPlayer, Status.STUNNED, ow1_flashbang_stun_duration)

--- a/src/ow1/heroes/mccree.opy
+++ b/src/ow1/heroes/mccree.opy
@@ -21,7 +21,7 @@ rule "[mccree.opy]: Throw projectile when pressing e":
     @Condition not eventPlayer.isUsingAbility1() # Ensure Cassidy is not rolling
     @Condition not eventPlayer.hasStatusEffect(Status.HACKED) # Ensure Cassidy is not hacked
 
-    createProjectile(Projectile.PHARAH_ROCKET, eventPlayer, null, null, Relativity.TO_WORLD, ModifyHealth.DAMAGE, getOppositeTeam(eventPlayer.getTeam()), 25, 1, 3, DynamicEffect.BAD_EXPLOSION, DynamicEffect.MCCREE_FLASHBANG_EXPLOSION_SOUND, 0, 30, 0.233, 0, 0, 1)
+    createProjectile(Projectile.ORB, eventPlayer, null, null, Relativity.TO_WORLD, ModifyHealth.DAMAGE, getOppositeTeam(eventPlayer.getTeam()), OW1_MCCREE_FLASHBANG_DAMAGE, 1, OW1_MCCREE_FLASHBANG_AOE_RADIUS, DynamicEffect.BAD_EXPLOSION, DynamicEffect.EXPLOSION_SOUND, 0, OW1_MCCREE_FLASHBANG_SPEED, OW1_MCCREE_FLASHBANG_RANGE/OW1_MCCREE_FLASHBANG_SPEED, 0, 0, 1)
     eventPlayer.setAbilityCooldown(Button.ABILITY_2, OW1_MCCREE_FLASHBANG_COOLDOWN)
 
 rule "[mccree.opy]: Stun flashed enemy":
@@ -29,4 +29,4 @@ rule "[mccree.opy]: Stun flashed enemy":
     @Condition eventAbility == 0
     @Condition attacker.getCurrentHero() == Hero.MCCREE or attacker.getCurrentHero() == Hero.GENJI
 
-    victim.setStatusEffect(eventPlayer, Status.STUNNED, ow1_flashbang_stun_duration)
+    victim.setStatusEffect(eventPlayer, Status.STUNNED, OW1_MCCREE_FLASHBANG_STUN_DURATION)


### PR DESCRIPTION
Use workshop's create projectile function to perfectly recreate Cassidy's flashbang from Overwatch 1.

Resolves #84, #64, #9 