### PR TITLE
Make melee cancel DVa boosters

### DIFF
--- a/src/ow1/heroes/dva.opy
+++ b/src/ow1/heroes/dva.opy
@@ -25,3 +25,23 @@ rule "[dva.opy]: Set default missile cooldown":
     
     waitUntil(not eventPlayer.isUsingAbility2(), 9999)
     eventPlayer.setAbilityCooldown(Button.ABILITY_2, OW1_DVA_MISSILE_COOLDOWN)
+
+rule "[dva.opy]: Decouple melee button from activating melee animation during booster":
+    @Event eachPlayer
+    @Hero dva
+    @Condition eventPlayer.isUsingAbility1()
+
+    eventPlayer.disallowButton(Button.MELEE)
+    waitUntil(not eventPlayer.isUsingAbility1(), 9999)
+    eventPlayer.allowButton(Button.MELEE)
+
+rule "[dva.opy]: Cancel booster if melee pressed":
+    @Event eachPlayer
+    @Hero dva
+    @Condition eventPlayer.isUsingAbility1()
+    @Condition eventPlayer.isHoldingButton(Button.MELEE)
+    
+    eventPlayer.forceButtonPress(Button.ABILITY_1)
+    eventPlayer.allowButton(Button.MELEE)
+    eventPlayer.forceButtonPress(Button.MELEE)
+    eventPlayer.disallowButton(Button.MELEE)


### PR DESCRIPTION
Decouple melee key from melee action during booster.

As soon as melee key is pressed during booster, first cancel booster (by forcing booster key), then, second, press melee key to activate melee.

The naive approach of detecting melee animation, then pressing booster to cancel, results in the melee animation cancelling, which isn't exactly OW1 behavior.