### PR TITLE
Remove knockback when in turret mode

### DIFF
--- a/src/ow1/heroes/bastion.opy
+++ b/src/ow1/heroes/bastion.opy
@@ -116,6 +116,7 @@ rule "[bastion.opy]: Initialize recon mode":
     eventPlayer.disallowButton(Button.SECONDARY_FIRE)
 
     eventPlayer.clearStatusEffect(Status.ROOTED)
+    eventPlayer.setKnockbackReceived(100)
     eventPlayer.allowButton(Button.PRIMARY_FIRE)
 
 
@@ -137,6 +138,7 @@ rule "[bastion.opy]: Initialize sentry mode":
 
     eventPlayer.setDamageDealt(percent(OW1_BASTION_MACHINE_GUN_DAMAGE/OW2_BASTION_MACHINE_GUN_DAMAGE))
     eventPlayer.setStatusEffect(null, Status.ROOTED, 9999)
+    eventPlayer.setKnockbackReceived(0)
 
     eventPlayer.disallowButton(Button.SECONDARY_FIRE)
 
@@ -166,6 +168,7 @@ rule "[bastion.opy]: Initialize tank mode":
     eventPlayer.disallowButton(Button.SECONDARY_FIRE)
 
     eventPlayer.clearStatusEffect(Status.ROOTED)
+    eventPlayer.setKnockbackReceived(100)
 
 
 rule "[bastion.opy]: Show sentry gui when in sentry mode":


### PR DESCRIPTION
Partially resolves #112. Confirmed to work like OW1 against dva boops, wreckingball boops/piledriver, reinhardt hammer swings, etc.

It's partial resolution because friendly teammates can still move the bastion inch by inch by bumping their hitboxes. In OW1, bastion was completely stationary even with teammates bumping their hitboxes.