### PR TITLE
Roadhog: Disable abilities and force autofire during ult

### DIFF
--- a/src/ow1/heroes/roadhog.opy
+++ b/src/ow1/heroes/roadhog.opy
@@ -30,3 +30,31 @@ rule "[roadhog.opy]: Set default hook cooldown":
     
     waitUntil(not eventPlayer.isUsingAbility1(), 9999)
     eventPlayer.setAbilityCooldown(Button.ABILITY_1, OW1_ROADHOG_HOOK_COOLDOWN)
+
+rule "[roadhog.opy]: Disable all abilities during ult":
+    @Event eachPlayer
+    @Hero roadhog
+    @Condition eventPlayer.isUsingUltimate() == true
+    
+    eventPlayer.setMeleeEnabled(false)
+    eventPlayer.setAbility1Enabled(false)
+    eventPlayer.setAbility2Enabled(false)
+    waitUntil(not eventPlayer.isUsingUltimate(), 9999)
+    eventPlayer.setMeleeEnabled(true)
+    eventPlayer.setAbility1Enabled(true)
+    eventPlayer.setAbility2Enabled(true)
+
+rule "[roadhog.opy]: Force autofire during ult":
+    @Event eachPlayer
+    @Hero roadhog
+    @Condition eventPlayer.isUsingUltimate() == true
+    @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) == false
+    
+    eventPlayer.startForcingButton(Button.PRIMARY_FIRE)
+
+rule "[roadhog.opy]: Stop autofire when not in ult":
+    @Event eachPlayer
+    @Hero roadhog
+    @Condition eventPlayer.isUsingUltimate() == false
+    
+    eventPlayer.stopForcingButton(Button.PRIMARY_FIRE)


### PR DESCRIPTION
This patch mostly fixes #138 with a few caveats.

List of bugs/nitpicks/things that can be improved:

1. I have yet to find a way that prevents the player from interefering by pressing the fire key. `setPrimaryFireEnabled` does not work in my testing, `forceButtonPress` messes up the rate of fire even when put in a loop that matches the ult's rate of fire, makes the viewmodel jump like crazy and is generally unoptimized, and `disallowButton` prevents you from firing altogether. My method makes it so it holds the fire button when it detects that you're not holding it during ult, but the caveat is that there's a slight delay before it starts forcing it again, therefore single clicks can ultimately manipulate the rate of fire.
2. I have yet to find a way to force OW1's duration without it looking clunky in the UI. There's no slider in the Hero settings either. For now it remains unchanged.
3. Rule that stops autofire can probably be optimized further.
4. More of a nitpick, but the abilities do not disable the moment you press the ult key, which happens in OW1. It doesn't seem to cause any harm in my testing but it does create a visual inconsistency.