### PR TITLE
fix infinite hp in between control rounds

### DIFF
--- a/src/ow1/reset_hero.opy
+++ b/src/ow1/reset_hero.opy
@@ -52,8 +52,8 @@ def resetHero():
 rule "[reset_hero.opy]: Reset hero on new round":
     @Event eachPlayer
     @Condition isMatchBetweenRounds() == true
-    
-    waitUntil(eventPlayer.isInSpawnRoom(), 60)
+
+    waitUntil(not isMatchBetweenRounds(), 9999)
     resetHero()
 
 


### PR DESCRIPTION
fixes #56 

If a hero health is modified by setCustomHealth(), the hero will have infinite health after each control round.

Before, the health reset was called on the condition that a) the round is transitioning and b) the player is in spawn room.
However, this caused issue when players died near the end of round and accidentally respawned in old spawn, triggerring the health reset in the old map before the round transition. This caused the hp to bug out to infinitiy when the map switched.

The fix is to detect when the round is transitioning, then wait until the round transition is over, and then reset health. This ensures that the health is reset on the new map instead of the old map (main trigger for the bug).