### PR TITLE
Push/pull slammed enemies towards Doomfist

### DIFF
--- a/src/ow1/heroes/doomfist.opy
+++ b/src/ow1/heroes/doomfist.opy
@@ -372,13 +372,9 @@ rule "[doomfist.opy]: Pull slammed victims":
     @Condition victim in attacker.slammed_victims
 
     victim.setGravity(50)
-    if distance(attacker, victim) < 2.5:
-        victim.applyImpulse(getLateralFacingDirection(eventPlayer) + Vector.UP, max(0, 8.5 - distance(eventPlayer, victim) * 2), Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
-        victim.setGravity(100)
-    else:
-        victim.applyImpulse(normalize(vect(vectorTowards(victim, eventPlayer).x, 0, vectorTowards(victim, eventPlayer).z)) + vect(0, 1, 0), 5 + distance(eventPlayer, victim) / 4, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
-        victim.setGravity(100)
-
+    # victim.applyImpulse(normalize(vect(vectorTowards(victim, eventPlayer).x, 0, vectorTowards(victim, eventPlayer).z)) + Vector.UP, 5 + distance(attacker, victim) / 4, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
+    victim.applyImpulse(Vector.UP, 5.25, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
+    victim.setGravity(100)
 
 rule "[doomfist.opy]: Indicator slam visibility":
     @Event eachPlayer

--- a/src/ow1/heroes/doomfist.opy
+++ b/src/ow1/heroes/doomfist.opy
@@ -365,6 +365,21 @@ rule "[doomfist.opy]: Damage slammed victims":
     attacker.slammed_victims.append(victim)
 
 
+rule "[doomfist.opy]: Pull slammed victims":
+    @Event playerDealtDamage
+    @Hero doomfist
+    @Condition eventAbility == Button.ABILITY_1 # Ability used to damage player is Seismic Slam
+    @Condition victim in attacker.slammed_victims
+
+    victim.setGravity(50)
+    if distance(attacker, victim) < 2.5:
+        victim.applyImpulse(getLateralFacingDirection(eventPlayer) + Vector.UP, max(0, 8.5 - distance(eventPlayer, victim) * 2), Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
+        victim.setGravity(100)
+    else:
+        victim.applyImpulse(normalize(vect(vectorTowards(victim, eventPlayer).x, 0, vectorTowards(victim, eventPlayer).z)) + vect(0, 1, 0), 5 + distance(eventPlayer, victim) / 4, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
+        victim.setGravity(100)
+
+
 rule "[doomfist.opy]: Indicator slam visibility":
     @Event eachPlayer
     @Hero doomfist

--- a/src/ow1/heroes/doomfist.opy
+++ b/src/ow1/heroes/doomfist.opy
@@ -372,8 +372,8 @@ rule "[doomfist.opy]: Pull slammed victims":
     @Condition victim in attacker.slammed_victims
 
     victim.setGravity(50)
-    # victim.applyImpulse(normalize(vect(vectorTowards(victim, eventPlayer).x, 0, vectorTowards(victim, eventPlayer).z)) + Vector.UP, 5 + distance(attacker, victim) / 4, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
-    victim.applyImpulse(Vector.UP, 5.25, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
+    victim.applyImpulse(Vector.UP, 5.25, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ) # Boop slammed victims up
+    victim.applyImpulse(directionTowards(victim, attacker), 1.5*(distance(victim, attacker)-OW1_DOOMFIST_RISING_UPPERCUT_RADIUS), Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ) # Push/Pull slammed victims; multiply pull magnitude by 1.5 to counteract air resistance
     victim.setGravity(100)
 
 rule "[doomfist.opy]: Indicator slam visibility":

--- a/src/ow1/heroes/doomfist.opy
+++ b/src/ow1/heroes/doomfist.opy
@@ -355,6 +355,15 @@ rule "[doomfist.opy]: Calculate slam damage based on air time":
     eventPlayer.slam_damage_gui_visible = false
 
 
+# Need more permanent/robust solution
+rule "[doomfist.opy]: Remove OW2 slam damage":
+    @Event playerDealtDamage
+    @Hero doomfist
+    @Condition eventAbility == Button.ABILITY_1 # Ability used to damage player is Seismic Slam
+    
+    heal(victim, null, eventDamage)
+
+
 rule "[doomfist.opy]: Find slammed victims":
     @Event playerDealtDamage
     @Hero doomfist
@@ -372,7 +381,7 @@ rule "[doomfist.opy]: Slammed victims damage and pull/push effects":
     @Condition eventAbility == Button.ABILITY_1 # Ability used to damage player is Seismic Slam
     @Condition victim in attacker.slammed_victims
 
-    damage(victim, attacker, round(attacker.slam_damage)-eventDamage) # Custom slam damage
+    damage(victim, attacker, round(attacker.slam_damage)) # Custom slam damage
     victim.setGravity(50) 
     victim.applyImpulse(Vector.UP, 5.25, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ) # Boop slammed victims up
     victim.applyImpulse(directionTowards(victim, attacker), 1.5*(distance(victim, attacker)-(OW1_DOOMFIST_RISING_UPPERCUT_RADIUS-1)), Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ) # Push/Pull slammed victims; multiply pull magnitude by 1.5 to counteract air resistance

--- a/src/ow1/heroes/doomfist.opy
+++ b/src/ow1/heroes/doomfist.opy
@@ -1,7 +1,7 @@
 #!mainFile "../../main.opy"
 
 /*
-This DPS doomfist workshop script is sourced from
+This DPS doomfist workshop script is heavily based on
 https://workshop.codes/dpsdoom        code: ZXJB4
 created by discord users: Bebel#5658 and Xponit#1474
 

--- a/src/ow1/heroes/doomfist.opy
+++ b/src/ow1/heroes/doomfist.opy
@@ -355,25 +355,27 @@ rule "[doomfist.opy]: Calculate slam damage based on air time":
     eventPlayer.slam_damage_gui_visible = false
 
 
-rule "[doomfist.opy]: Damage slammed victims":
+rule "[doomfist.opy]: Find slammed victims":
     @Event playerDealtDamage
     @Hero doomfist
     @Condition eventAbility == Button.ABILITY_1 # Ability used to damage player is Seismic Slam
-    # [TODO] add more conditions to check that the player is inside OW1 slam hitbox
-
-    damage(victim, attacker, round(attacker.slam_damage)-eventDamage)
+    @Condition OW1_DOOMFIST_SEISMIC_SLAM_AOE_MIN_RADIUS <= distance(attacker, victim)
+    @Condition distance(attacker, victim) <= OW1_DOOMFIST_SEISMIC_SLAM_AOE_MAX_RADIUS
+    # TODO add condition to check victim in 60 degree cone
+    
     attacker.slammed_victims.append(victim)
 
 
-rule "[doomfist.opy]: Pull slammed victims":
+rule "[doomfist.opy]: Slammed victims damage and pull/push effects":
     @Event playerDealtDamage
     @Hero doomfist
     @Condition eventAbility == Button.ABILITY_1 # Ability used to damage player is Seismic Slam
     @Condition victim in attacker.slammed_victims
 
-    victim.setGravity(50)
+    damage(victim, attacker, round(attacker.slam_damage)-eventDamage) # Custom slam damage
+    victim.setGravity(50) 
     victim.applyImpulse(Vector.UP, 5.25, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ) # Boop slammed victims up
-    victim.applyImpulse(directionTowards(victim, attacker), 1.5*(distance(victim, attacker)-OW1_DOOMFIST_RISING_UPPERCUT_RADIUS), Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ) # Push/Pull slammed victims; multiply pull magnitude by 1.5 to counteract air resistance
+    victim.applyImpulse(directionTowards(victim, attacker), 1.5*(distance(victim, attacker)-(OW1_DOOMFIST_RISING_UPPERCUT_RADIUS-1)), Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ) # Push/Pull slammed victims; multiply pull magnitude by 1.5 to counteract air resistance
     victim.setGravity(100)
 
 rule "[doomfist.opy]: Indicator slam visibility":


### PR DESCRIPTION
Code consists of 2 parts: OW1 slam detection and OW1 slam effects

OW1 slam detection is handled by the rule "Find slammed victims". This rule ensures that the victim is within the OW1 slammable range (1~8m)  and stores that enemy into the array to be used later.

In "Find slammed victims" rule, custom slam damage is applied, then the target is booped up and pushed/pulled to be ~4m away from the doomfist. The impulse upwards and sideways are handled seperately for mental clarify.

In addtiion, OW2 slam damage has been removed by immediately healing that damage in "Remove OW2 slam damage" rule.