### PR TITLE
Subtract time hook was active from Roadhog's hook CD

### DIFF
--- a/src/ow1/heroes/roadhog.opy
+++ b/src/ow1/heroes/roadhog.opy
@@ -1,6 +1,7 @@
 #!mainFile "../../main.opy"
 
 subroutine initRoadhog
+playervar time_hook_was_active 0
 
 rule "[roadhog.opy]: Detect Roadhog initialization":
     @Event eachPlayer
@@ -31,8 +32,10 @@ rule "[roadhog.opy]: Set default hook cooldown":
     @Hero roadhog
     @Condition eventPlayer.isUsingAbility1()
     
-    waitUntil(not eventPlayer.isUsingAbility1(), 9999)
-    eventPlayer.setAbilityCooldown(Button.ABILITY_1, OW1_ROADHOG_HOOK_COOLDOWN_TIME)
+    eventPlayer.time_hook_was_active = 0
+    chase(eventPlayer.time_hook_was_active, 3, rate=1, ChaseReeval.NONE)
+    waitUntil(not eventPlayer.isUsingAbility1(), 99999)
+    eventPlayer.setAbilityCooldown(Button.ABILITY_1, OW1_ROADHOG_HOOK_COOLDOWN_TIME - eventPlayer.time_hook_was_active)
 
 
 rule "[roadhog.opy]: Disable all abilities during ult":


### PR DESCRIPTION
Fixes #223.

Essentially a timer begins when Roadhog launches his hook, which stops when the hook is retrieved. The duration is then subtracted from the cooldown time.