### PR TITLE
More cost efficient radius los check on Orisa supercharger and halt

### DIFF
--- a/src/ow1/heroes/orisa.opy
+++ b/src/ow1/heroes/orisa.opy
@@ -131,11 +131,10 @@ def endSupercharger():
 rule "[orisa.opy]: Supercharge teammates in supercharger range":
     @Event eachPlayer
     @Hero all
+    @Condition eventPlayer.isAlive() == true
     @Condition eventPlayer.friendly_orisa_player.is_using_supercharger == true
-    @Condition eventPlayer in getPlayersInRadius(eventPlayer.friendly_orisa_player.orisa_supercharger_position, 
-                                                 OW1_ORISA_SUPERCHARGER_AOE_RADIUS, 
-                                                 eventPlayer.friendly_orisa_player.getTeam(), 
-                                                 LosCheck.SURFACES_AND_ENEMY_BARRIERS)
+    @Condition distance(eventPlayer, eventPlayer.friendly_orisa_player.orisa_supercharger_position) <= OW1_ORISA_SUPERCHARGER_AOE_RADIUS and \
+               isInLoS(eventPlayer, eventPlayer.friendly_orisa_player.orisa_supercharger_position, BarrierLos.PASS_THROUGH_BARRIERS) == true
     
     eventPlayer.is_supercharged = true
 
@@ -143,12 +142,10 @@ rule "[orisa.opy]: Supercharge teammates in supercharger range":
 rule "[orisa.opy]: De-supercharge teammates outside supercharger range":
     @Event eachPlayer
     @Hero all
-    @Condition eventPlayer.friendly_orisa_player.is_using_supercharger == true
-    @Condition eventPlayer not in getPlayersInRadius(eventPlayer.friendly_orisa_player.orisa_supercharger_position, 
-                                                     OW1_ORISA_SUPERCHARGER_AOE_RADIUS, 
-                                                     eventPlayer.friendly_orisa_player.getTeam(), 
-                                                     LosCheck.SURFACES_AND_ENEMY_BARRIERS)
     @Condition eventPlayer.is_supercharged == true
+    @Condition eventPlayer.friendly_orisa_player.is_using_supercharger == true
+    @Condition distance(eventPlayer, eventPlayer.friendly_orisa_player.orisa_supercharger_position) <= OW1_ORISA_SUPERCHARGER_AOE_RADIUS and \
+               isInLoS(eventPlayer, eventPlayer.friendly_orisa_player.orisa_supercharger_position, BarrierLos.PASS_THROUGH_BARRIERS) == false
     
     wait(OW1_ORISA_SUPERCHARGER_LINGER_TIME, Wait.ABORT_WHEN_FALSE)
     eventPlayer.is_supercharged = false
@@ -158,6 +155,14 @@ rule "[orisa.opy]: De-supercharge teammates when supercharger ends":
     @Event eachPlayer
     @Hero all
     @Condition eventPlayer.friendly_orisa_player.is_using_supercharger == false
+    
+    eventPlayer.is_supercharged = false
+
+
+rule "[orisa.opy]: De-supercharge teammates when they die":
+    @Event eachPlayer
+    @Hero all
+    @Condition eventPlayer.isDead() == true
     
     eventPlayer.is_supercharged = false
 
@@ -249,8 +254,9 @@ rule "[orisa.opy]: Pull halted victims":
 rule "[orisa.opy]: Create Halt pull line vfx when in pull range":
     @Event eachPlayer
     @Condition eventPlayer.enemy_orisa_player.is_using_halt == true
-    @Condition eventPlayer in getPlayersInRadius(eventPlayer.enemy_orisa_player.halt_position, OW1_ORISA_HALT_AOE_RADIUS, eventPlayer.getTeam(), LosCheck.SURFACES_AND_ALL_BARRIERS)
-
+    @Condition distance(eventPlayer, eventPlayer.enemy_orisa_player.halt_position) <= OW1_ORISA_HALT_AOE_RADIUS and \
+               isInLoS(eventPlayer, eventPlayer.enemy_orisa_player.halt_position, BarrierLos.BLOCKED_BY_ALL_BARRIERS) == true
+    
     createBeam(getAllPlayers(), Beam.GOOD, eventPlayer.enemy_orisa_player.halt_position, eventPlayer, Color.LIME_GREEN, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
     eventPlayer.halt_pull_line_entity = getLastCreatedEntity()
     eventPlayer.entity_huds.append(eventPlayer.halt_pull_line_entity)
@@ -259,8 +265,9 @@ rule "[orisa.opy]: Create Halt pull line vfx when in pull range":
 rule "[orisa.opy]: Destroy Halt pull line vfx when not in pull range":
     @Event eachPlayer
     @Condition eventPlayer.enemy_orisa_player.is_using_halt == true
-    @Condition eventPlayer not in getPlayersInRadius(eventPlayer.enemy_orisa_player.halt_position, OW1_ORISA_HALT_AOE_RADIUS, eventPlayer.getTeam(), LosCheck.SURFACES_AND_ALL_BARRIERS)
-
+    @Condition distance(eventPlayer, eventPlayer.enemy_orisa_player.halt_position) <= OW1_ORISA_HALT_AOE_RADIUS and \
+               isInLoS(eventPlayer, eventPlayer.enemy_orisa_player.halt_position, BarrierLos.BLOCKED_BY_ALL_BARRIERS) == false
+    
     destroyEffect(eventPlayer.halt_pull_line_entity)
     eventPlayer.entity_huds.remove(eventPlayer.halt_pull_line_entity)
 


### PR DESCRIPTION
This new technique should be at least 2x more effcient at checking if a player is in randius and in LOS.

The current method first requires that the game generate an array of players in radius and los, then checks if a given player belongs to that array. This process is expensive because a) calculations related to any player in the array besides the player executing rule is redundant and b) finding an element in array takes linear time.

The new method only performs calculation for the rule executing player, cutting down the number of calculations required by at least 2x.