### PR TITLE
More accurate hook pull distance

### DIFF
--- a/src/ow1/heroes/roadhog.opy
+++ b/src/ow1/heroes/roadhog.opy
@@ -96,7 +96,11 @@ rule "[roadhog.opy]: Move hooked enemies closer":
     @Condition eventPlayer.isUsingAbility1() == true
 
     waitUntil(eventPlayer.isUsingAbility1() == false, 9999)
-    victim.applyImpulse(directionTowards(victim, attacker), 25*(OW2_ROADHOG_HOOK_PROXIMITY-OW1_ROADHOG_HOOK_PROXIMITY), Relativity.TO_WORLD, Impulse.INCORPORATE_CONTRARY_MOTION)
+    if distance(victim, attacker) <= OW2_ROADHOG_HOOK_PROXIMITY:
+        victim.startForcingPosition(attacker.getPosition() + OW1_ROADHOG_HOOK_PROXIMITY*directionTowards(attacker, victim), false)
+        wait()
+        victim.stopForcingPosition()
+
 
 rule "[roadhog.opy]: Reduce ultimate duration":
     @Event eachPlayer


### PR DESCRIPTION
Instead of nudging the victim with an arbitrary impulse, teleport the victim 3m in front of the hog player.