### PR TITLE
feat: add debug menu option

### DIFF
--- a/src/main.opy
+++ b/src/main.opy
@@ -5,7 +5,6 @@
 #!include "constants/ow2_constants.opy"
 
 # Useful functions
-#!include "utilities/debug.opy"
 #!include "utilities/macro_functions.opy"
 #!include "utilities/hero_switch.opy"
 #!include "utilities/role_lock.opy"
@@ -16,3 +15,6 @@
 #!include "lobby_settings.opy"
 # OW1 logic
 #!include "ow1/ow1.opy"
+
+# Include debug at the end so any variable can be viewed
+#!include "utilities/debug.opy"

--- a/src/utilities/debug.opy
+++ b/src/utilities/debug.opy
@@ -1,21 +1,26 @@
 #!mainFile "../main.opy"
 
-rule "[debug.opy]: Display server performance characteristics":
-    @Disabled
-    hudHeader(getAllPlayers(), l"{0}: {1}".format(l"Server Load", l"{0}%".format(getServerLoad())), HudPosition.LEFT, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-    hudHeader(getAllPlayers(), l"{0}: {1}".format(l"Server Load Average", l"{0}%".format(getAverageServerLoad())), HudPosition.LEFT, 1, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-    hudHeader(getAllPlayers(), l"{0}: {1}".format(l"Server Load Peak", l"{0}%".format(getPeakServerLoad())), HudPosition.LEFT, 2, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+globalvar debug = createWorkshopSetting(bool, "Dev Tools", "debug mode", false)
+
+rule "[debug.opy]: global debug (Top Left)":
+    @Condition debug == true
+
+    hudSubheader(getAllPlayers(), "Server Load: {}%".format(getServerLoad()), HudPosition.LEFT, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING)
+    hudSubheader(getAllPlayers(), "Server Load Average: {}%".format(getAverageServerLoad()), HudPosition.LEFT, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING)
+    hudSubheader(getAllPlayers(), "Server Load Peak: {}%".format(getPeakServerLoad()), HudPosition.LEFT, 0, Color.WHITE, HudReeval.VISIBILITY_AND_STRING)
 
 
-rule "[debug.opy]: Debug HUD text":
-    @Disabled
+rule "[debug.opy]: player debug (Top Right)":
     @Event eachPlayer
+    @Condition debug == true
     
-    hudSubheader(eventPlayer, "{}".format(eventPlayer.getAltitude()), HudPosition.TOP, 0, Color.WHITE, HudReeval.STRING)
+    hudSubheader(eventPlayer, "altitude: {}".format(eventPlayer.getAltitude()), HudPosition.RIGHT, 0, Color.WHITE, HudReeval.STRING)
+    hudSubheader(eventPlayer, "Hacked?: {}".format(eventPlayer.hasStatusEffect(Status.HACKED)), HudPosition.RIGHT, 0, Color.WHITE, HudReeval.STRING)
+    hudSubheader(eventPlayer, "Hero Damage Dealt: {}".format(eventPlayer.getStatistic(Stat.HERO_DAMAGE_DEALT)), HudPosition.RIGHT, 0, Color.WHITE, HudReeval.STRING)
 
 
 rule "[debug.opy]: Debug damage instance":
-    @Disabled
     @Event playerDealtDamage
+    @Condition debug == true
 
     printLog("{} {} {}".format(eventPlayer.getCurrentHero(), eventAbility, eventDamage))


### PR DESCRIPTION
Add a workshop ui rule for enabling/disabling debugging.

Also include the `debug.opy` file last in the source code to make all variables visible to the debug module.