### PR TITLE
feat: skip setup time by readying players

### DIFF
--- a/src/main.opy
+++ b/src/main.opy
@@ -8,6 +8,7 @@
 #!include "utilities/macro_functions.opy"
 #!include "utilities/hero_switch.opy"
 #!include "utilities/role_lock.opy"
+#!include "utilities/ready.opy"
 #!include "utilities/custom_health_handler.opy"
 #!include "utilities/hit_detection.opy"
 

--- a/src/utilities/ready.opy
+++ b/src/utilities/ready.opy
@@ -1,0 +1,42 @@
+#!mainFile "../main.opy"
+
+playervar ready
+
+rule "[ready.opy]: Unready all players when entering setup":
+    @Event eachPlayer
+    @Condition isInSetup() == true
+
+    eventPlayer.ready = false
+
+
+rule "[ready.opy]: Toggle ready when pressing Interact + Reload":
+    @Event eachPlayer
+    @Condition isInSetup() == true
+    @Condition eventPlayer.isHoldingButton(Button.INTERACT) == true
+    @Condition eventPlayer.isHoldingButton(Button.RELOAD) == true
+
+    eventPlayer.ready = not eventPlayer.ready # Toggle readiness
+
+
+rule "[ready.opy]: Display message when ready":
+    @Event eachPlayer
+    @Condition eventPlayer.ready == true
+
+    bigMessage(eventPlayer, "Ready")
+
+
+rule "[ready.opy]: Display message when not ready":
+    @Event eachPlayer
+    @Condition eventPlayer.ready == false
+
+    bigMessage(eventPlayer, "Not Ready")
+
+
+rule "[ready.opy]: Start match when everyone ready":
+    @Event global
+    @Condition isGameInProgress() == false # Guard to prevent incorrect match time modification
+    @Condition isAssemblingHeroes() == false # Guard to prevent incorrect match time modification
+    @Condition isInSetup() == true
+    @Condition all([player.ready for player in getAllPlayers()]) == true
+
+    setMatchTime(5)


### PR DESCRIPTION
Press interact + reload to ready players, then skip setup time when everyone's ready