### PR TITLE
feat: smoother Mercy slingshot during GA

### DIFF
--- a/src/constants/ow1_constants.opy
+++ b/src/constants/ow1_constants.opy
@@ -2,7 +2,6 @@
 
 # Generic
 #!define SETUP_BUFFER_TIME 5
-#!define OW1_JUMP_SPEED 5.44
 
 ###################################
 # Ult Costs

--- a/src/constants/ow1_constants.opy
+++ b/src/constants/ow1_constants.opy
@@ -2,7 +2,7 @@
 
 # Generic
 #!define SETUP_BUFFER_TIME 5
-#!define OW1_JUMP_SPEED 5.44
+#!define OW1_JUMP_SPEED 6
 
 ###################################
 # Ult Costs
@@ -180,6 +180,7 @@
 #!define OW1_MERCY_GUARDIAN_ANGEL_COOLDOWN 1.5
 #!define OW1_MERCY_GUARDIAN_ANGEL_MAX_SPEED 17
 #!define OW1_MERCY_GUARDIAN_ANGEL_RECOVERY_TIME 1
+#!define OW1_MERCY_SLINGSHOT_DURATION 1
 
 # Orisa
 #!define OW1_ORISA_CLIP_SIZE 150

--- a/src/constants/ow1_constants.opy
+++ b/src/constants/ow1_constants.opy
@@ -2,6 +2,7 @@
 
 # Generic
 #!define SETUP_BUFFER_TIME 5
+#!define OW1_JUMP_SPEED 5.44
 
 ###################################
 # Ult Costs

--- a/src/ow1/heroes/mercy/guardian.opy
+++ b/src/ow1/heroes/mercy/guardian.opy
@@ -2,6 +2,7 @@
 
 playervar is_using_guardian_angel
 playervar is_slingshotting
+playervar slingshot_velocity
 
 
 rule "[mercy/guardian.opy]: Initialize Guardian Angel Ability":
@@ -43,8 +44,9 @@ rule "[mercy/guardian.opy]: Define GA slingshot":
     @Condition eventPlayer.isHoldingButton(Button.JUMP)
 
     eventPlayer.cancelPrimaryAction()
+    eventPlayer.slingshot_velocity = eventPlayer.getVelocity()
     eventPlayer.is_slingshotting = true
-    waitUntil(not eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isOnGround(), 3)
+    waitUntil(not eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isOnGround(), OW1_MERCY_SLINGSHOT_DURATION)
     eventPlayer.is_slingshotting = false
 
 
@@ -64,11 +66,12 @@ rule "[mercy/guardian.opy]: Give speed boost during slingshot":
     @Hero mercy
     @Condition eventPlayer.is_slingshotting == true
     
-    eventPlayer.setMoveSpeed(300)
-    eventPlayer.startForcingThrottle(0, 0, 0, 0, 0, 0)
-    waitUntil(eventPlayer.isOnGround(), 1)
-    eventPlayer.setMoveSpeed(100)
-    eventPlayer.stopForcingThrottle()
+    while eventPlayer.is_slingshotting:
+        eventPlayer.applyImpulse(eventPlayer.slingshot_velocity, 
+                                0.8, # Arbitrarily decided based on trial & error
+                                Relativity.TO_WORLD, 
+                                Impulse.INCORPORATE_CONTRARY_MOTION)
+        wait()
 
 
 rule "[mercy/guardian.opy]: Force angelic descent during slingshot":

--- a/src/ow1/heroes/mercy/guardian.opy
+++ b/src/ow1/heroes/mercy/guardian.opy
@@ -49,12 +49,10 @@ rule "[mercy/guardian.opy]: Define GA slingshot":
 
 def startSlingshot():
     @Name "[mercy/guardian.opy]: startSlingshot()"
-    # if eventPlayer.isHoldingButton(Button.CROUCH): # add extra vertical momentum for superjump
-    #     eventPlayer.slingshot_initial_velocity += eventPlayer.getVelocity()/3
 
     eventPlayer.is_slingshotting = true
-    eventPlayer.applyImpulse(eventPlayer.getVelocity() + OW1_JUMP_SPEED*Vector.UP, 
-                             magnitude(eventPlayer.getVelocity() + OW1_JUMP_SPEED*Vector.UP), 
+    eventPlayer.applyImpulse(normalize(eventPlayer.getVelocity()) + 0.5 * Vector.UP, 
+                             updateEveryTick(eventPlayer.getSpeed()), 
                              Relativity.TO_WORLD, 
                              Impulse.INCORPORATE_CONTRARY_MOTION)
     eventPlayer.cancelPrimaryAction()

--- a/src/ow1/heroes/mercy/guardian.opy
+++ b/src/ow1/heroes/mercy/guardian.opy
@@ -3,8 +3,6 @@
 playervar is_using_guardian_angel
 playervar is_slingshotting
 
-subroutine startSlingshot
-
 
 rule "[mercy/guardian.opy]: Initialize Guardian Angel Ability":
     @Event eachPlayer
@@ -44,24 +42,44 @@ rule "[mercy/guardian.opy]: Define GA slingshot":
     @Condition eventPlayer.is_using_guardian_angel == true
     @Condition eventPlayer.isHoldingButton(Button.JUMP)
 
-    startSlingshot()
-
-
-def startSlingshot():
-    @Name "[mercy/guardian.opy]: startSlingshot()"
-
+    eventPlayer.cancelPrimaryAction()
     eventPlayer.is_slingshotting = true
-    eventPlayer.applyImpulse(normalize(eventPlayer.getVelocity()) + 0.5 * Vector.UP, 
-                             updateEveryTick(eventPlayer.getSpeed()), 
+    waitUntil(not eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isOnGround(), 3)
+    eventPlayer.is_slingshotting = false
+
+
+rule "[mercy/guardian.opy]: Apply upwards momentum when starting slingshot":
+    @Event eachPlayer
+    @Hero mercy
+    @Condition eventPlayer.is_slingshotting == true
+
+    eventPlayer.applyImpulse(Vector.UP, 
+                             OW1_JUMP_SPEED , 
                              Relativity.TO_WORLD, 
                              Impulse.INCORPORATE_CONTRARY_MOTION)
-    eventPlayer.cancelPrimaryAction()
-    # Force angelic descent
+
+
+rule "[mercy/guardian.opy]: Give speed boost during slingshot":
+    @Event eachPlayer
+    @Hero mercy
+    @Condition eventPlayer.is_slingshotting == true
+    
+    eventPlayer.setMoveSpeed(300)
+    eventPlayer.startForcingThrottle(0, 0, 0, 0, 0, 0)
+    waitUntil(eventPlayer.isOnGround(), 1)
+    eventPlayer.setMoveSpeed(100)
+    eventPlayer.stopForcingThrottle()
+
+
+rule "[mercy/guardian.opy]: Force angelic descent during slingshot":
+    @Event eachPlayer
+    @Hero mercy
+    @Condition eventPlayer.is_slingshotting == true
+    
     eventPlayer.allowButton(Button.JUMP)
     eventPlayer.startForcingButton(Button.JUMP)
     waitUntil(not eventPlayer.isHoldingButton(Button.JUMP), 99999)
     eventPlayer.stopForcingButton(Button.JUMP)
-    eventPlayer.is_slingshotting = false
 
 
 rule "[mercy/guardian.opy]: Slingshot GA cooldown logic":


### PR DESCRIPTION
partially resolves #420

Instead of applying a single impulse after activating slingshot, apply a series of tiny impulses during the entirety of slingshot for smoother speed curve.